### PR TITLE
PoC: Dev of KPIs for mapeditor

### DIFF
--- a/src/rtctools_heat_network/esdl/asset_to_component_base.py
+++ b/src/rtctools_heat_network/esdl/asset_to_component_base.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("rtctools_heat_network")
 
 MODIFIERS = Dict[str, Union[str, int, float]]
 
-HEAT_STORAGE_M3_WATER_PER_DEGREE_CELCIUS = 4200 * 998
+HEAT_STORAGE_M3_WATER_PER_DEGREE_CELCIUS = 4200 * 988
 WATTHOUR_TO_JOULE = 3600
 
 MULTI_ENUM_NAME_TO_FACTOR = {

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -175,8 +175,7 @@ class EndScenarioSizing(
                 else:
                     total_demand += demand_values
                 max_demand = max(demand_values)
-                # TODO: check why (0.0, 2.0 * max_demand) caused investment to go to upper bound
-                self.__heat_demand_bounds[f"{demand}.Heat_demand"] = (0.0, max_demand)
+                self.__heat_demand_bounds[f"{demand}.Heat_demand"] = (0.0, 2.0 * max_demand)
                 self.__heat_demand_nominal[f"{demand}.Heat_demand"] = max_demand
 
             # TODO: the approach of picking one peak day was introduced for a network with a tree

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -175,7 +175,8 @@ class EndScenarioSizing(
                 else:
                     total_demand += demand_values
                 max_demand = max(demand_values)
-                self.__heat_demand_bounds[f"{demand}.Heat_demand"] = (0.0, 2 * max_demand)
+                # TODO: check why (0.0, 2.0 * max_demand) caused investment to go to upper bound
+                self.__heat_demand_bounds[f"{demand}.Heat_demand"] = (0.0, max_demand)
                 self.__heat_demand_nominal[f"{demand}.Heat_demand"] = max_demand
 
             # TODO: the approach of picking one peak day was introduced for a network with a tree

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import uuid
 from pathlib import Path
@@ -11,6 +12,8 @@ import pandas as pd
 from rtctools_heat_network.esdl.edr_pipe_class import EDRPipeClass
 from rtctools_heat_network.heat_mixin import HeatMixin
 from rtctools_heat_network.workflows.utils.helpers import _sort_numbered
+
+logger = logging.getLogger("rtctools_heat_network")
 
 
 class ScenarioOutput(HeatMixin):
@@ -220,20 +223,12 @@ class ScenarioOutput(HeatMixin):
                 (x for x in energy_system.eAllContents() if hasattr(x, "name") and x.name == name)
             )
 
-        kpis_top_level = esdl.KPIs(id=str(uuid.uuid4()))
-        total_investment = 0.
-        total_installation = 0.
-        total_variable_opex = 0.
-        total_fixed_opex = 0.
-        energy = {}
-
         # ------------------------------------------------------------------------------------------
-        # Cost breakdowns
-        # code from Ewoud
-        # # energysystem.id = str(uuid.uuid4())
-
-        # # energysystem.name = energysystem.name + "_optimized"
-        # Below we do multiple breakdown on an aggregated level and add them to the top level
+        # KPIs
+        # General cost breakdowns
+        # ------------------------------------------------------------------------------------------
+        kpis_top_level = esdl.KPIs(id=str(uuid.uuid4()))
+        energy_wh = {}
         capex_breakdown = {}
         opex_breakdown = {}
         tot_install_cost_euro = 0.0
@@ -241,78 +236,86 @@ class ScenarioOutput(HeatMixin):
         tot_variable_opex_cost_euro = 0.0
         tot_fixed_opex_cost_euro = 0.0
 
-        for key, asset in self.esdl_assets.items():
-
-            is_asset_energy_source = False
-            if (asset.asset_type == "HeatProducer"
+        for _key, asset in self.esdl_assets.items():
+            is_asset_opex_included = False
+            if (
+                asset.asset_type == "HeatProducer"
                 or asset.asset_type == "GenericProducer"
                 or asset.asset_type == "ResidualHeatSource"
                 or asset.asset_type == "GeothermalSource"
                 or asset.asset_type == "ResidualHeatSource"
                 or asset.asset_type == "GasHeater"
             ):
-                is_asset_energy_source = True
+                is_asset_opex_included = True
+
             asset_placement_var = self._asset_aggregation_count_var_map[asset.name]
             placed = np.round(results[asset_placement_var][0]) >= 1.0
-
             if placed:
                 try:
-                    capex_breakdown[asset.asset_type] += (
-                        results[f"{asset.name}__investment_cost"][0]
-                        + results[f"{asset.name}__installation_cost"][0]
-                    )
-
                     tot_install_cost_euro += results[f"{asset.name}__installation_cost"][0]
                     tot_invest_cost_euro += results[f"{asset.name}__investment_cost"][0]
+                    capex_breakdown[asset.asset_type] += (
+                        tot_install_cost_euro + tot_invest_cost_euro
+                    )
 
-                    if is_asset_energy_source:
-                        opex_breakdown[asset.asset_type] += (
-                            results[f"{asset.name}__variable_operational_cost"][0]
-                            + results[f"{asset.name}__fixed_operational_cost"][0]
-                        )
+                    if is_asset_opex_included:
                         tot_variable_opex_cost_euro += results[
-                            f"{asset.name}__variable_operational_cost"][0]
+                            f"{asset.name}__variable_operational_cost"
+                        ][0]
                         tot_fixed_opex_cost_euro += results[
-                            f"{asset.name}__fixed_operational_cost"][0]
+                            f"{asset.name}__fixed_operational_cost"
+                        ][0]
+                        opex_breakdown[asset.asset_type] += (
+                            tot_variable_opex_cost_euro + tot_fixed_opex_cost_euro
+                        )
 
                 except KeyError:
                     try:
+                        tot_install_cost_euro = results[f"{asset.name}__installation_cost"][0]
+                        tot_invest_cost_euro = results[f"{asset.name}__investment_cost"][0]
                         capex_breakdown[asset.asset_type] = (
-                            results[f"{asset.name}__investment_cost"][0]
-                            + results[f"{asset.name}__installation_cost"][0]
+                            tot_install_cost_euro + tot_invest_cost_euro
                         )
 
-                        tot_install_cost_euro += results[f"{asset.name}__installation_cost"][0]
-                        tot_invest_cost_euro += results[f"{asset.name}__investment_cost"][0]
-
-                        if is_asset_energy_source: 
-                            opex_breakdown[asset.asset_type] = (
-                                results[f"{asset.name}__variable_operational_cost"][0]
-                                + results[f"{asset.name}__fixed_operational_cost"][0])
+                        if is_asset_opex_included:
                             tot_variable_opex_cost_euro = results[
-                                f"{asset.name}__variable_operational_cost"][0]
+                                f"{asset.name}__variable_operational_cost"
+                            ][0]
                             tot_fixed_opex_cost_euro = results[
-                                f"{asset.name}__fixed_operational_cost"][0]
-
-                    except:
+                                f"{asset.name}__fixed_operational_cost"
+                            ][0]
+                            opex_breakdown[asset.asset_type] = (
+                                tot_variable_opex_cost_euro + tot_fixed_opex_cost_euro
+                            )
+                    except KeyError:
+                        # Do not add any costs. Items like joint
                         pass
 
-                if is_asset_energy_source:
-                    energy[asset.name] = np.sum(results[f"{asset.name}.Heat_source"])
+                if is_asset_opex_included:
+                    energy_wh[asset.name] = np.sum(
+                        results[f"{asset.name}.Heat_source"][1:]
+                        * (self.times()[1:] - self.times()[0:-1])
+                        / 3600
+                    )
 
         kpis_top_level.kpi.append(
             esdl.DistributionKPI(
                 name="High level cost breakdown [EUR]",
                 distribution=esdl.StringLabelDistribution(
                     stringItem=[
-                        esdl.StringItem(label="CAPEX", value=tot_install_cost_euro+tot_invest_cost_euro),
-                        esdl.StringItem(label="OPEX", value=tot_variable_opex_cost_euro+tot_fixed_opex_cost_euro),
+                        esdl.StringItem(
+                            label="CAPEX",
+                            value=tot_install_cost_euro + tot_invest_cost_euro,
+                        ),
+                        esdl.StringItem(
+                            label="OPEX",
+                            value=tot_variable_opex_cost_euro + tot_fixed_opex_cost_euro,
+                        ),
                     ]
                 ),
                 quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                    physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                    unit=esdl.UnitEnum.EURO
-                )
+                    physicalQuantity=esdl.PhysicalQuantityEnum.COST, unit=esdl.UnitEnum.EURO
+                ),
             )
         )
 
@@ -324,13 +327,12 @@ class ScenarioOutput(HeatMixin):
                         esdl.StringItem(label="Installation", value=tot_install_cost_euro),
                         esdl.StringItem(label="Investment", value=tot_invest_cost_euro),
                         esdl.StringItem(label="Variable OPEX", value=tot_variable_opex_cost_euro),
-                        esdl.StringItem(label="Fixed OPEX", value=tot_fixed_opex_cost_euro)
+                        esdl.StringItem(label="Fixed OPEX", value=tot_fixed_opex_cost_euro),
                     ]
                 ),
                 quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                    physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                    unit=esdl.UnitEnum.EURO
-                )
+                    physicalQuantity=esdl.PhysicalQuantityEnum.COST, unit=esdl.UnitEnum.EURO
+                ),
             )
         )
 
@@ -339,14 +341,13 @@ class ScenarioOutput(HeatMixin):
                 name="CAPEX breakdown [EUR]",
                 distribution=esdl.StringLabelDistribution(
                     stringItem=[
-                        esdl.StringItem(label=key, value=value) for key,
-                        value in capex_breakdown.items()
+                        esdl.StringItem(label=key, value=value)
+                        for key, value in capex_breakdown.items()
                     ]
                 ),
                 quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                    physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                    unit=esdl.UnitEnum.EURO
-                )
+                    physicalQuantity=esdl.PhysicalQuantityEnum.COST, unit=esdl.UnitEnum.EURO
+                ),
             )
         )
 
@@ -355,32 +356,40 @@ class ScenarioOutput(HeatMixin):
                 name="OPEX breakdown [EUR]",
                 distribution=esdl.StringLabelDistribution(
                     stringItem=[
-                        esdl.StringItem(label=key, value=value) for key,
-                        value in opex_breakdown.items()
+                        esdl.StringItem(label=key, value=value)
+                        for key, value in opex_breakdown.items()
                     ]
                 ),
                 quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                    physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                    unit=esdl.UnitEnum.EURO
-                )
+                    physicalQuantity=esdl.PhysicalQuantityEnum.COST, unit=esdl.UnitEnum.EURO
+                ),
             )
         )
 
         kpis_top_level.kpi.append(
             esdl.DistributionKPI(
-                name="Overall Production breakdown [EUR]",
+                name="Energy production [Wh]",
                 distribution=esdl.StringLabelDistribution(
                     stringItem=[
-                        esdl.StringItem(label=key, value=value) for key,
-                        value in energy.items()
+                        esdl.StringItem(label=key, value=value) for key, value in energy_wh.items()
                     ]
-                )
+                ),
             )
         )
         energy_system.instance[0].area.KPIs = kpis_top_level
-# #-----------------------------------------------------------------------------------------------------------------------------------------------------
-        # Here we loop over the subarea and assign KPIs to the subareas
+        # ------------------------------------------------------------------------------------------
+        # Cost breakdowns per polygon areas (can consist of several assets of differents types)
+        # Notes:
+        # - OPEX KPIs are taken into account for energy sources only.
+        # - We assume that all energy produced outside of the the subarea comes in via a heat
+        #   exchanger that is part of the subarea.
         for subarea in energy_system.instance[0].area.area:
+            area_investment_cost = 0.0
+            area_installation_cost = 0.0
+            area_variable_opex_cost = 0.0
+            area_fixed_opex_cost = 0.0
+
+            is_at_least_asset_opex_included = False
             kpis = esdl.KPIs(id=str(uuid.uuid4()))
             # Here we make a breakdown of the produced energy in the subarea. Where we assume that
             # all energy produced outside of the the subarea comes in via a heat exchanger that is
@@ -390,150 +399,163 @@ class ScenarioOutput(HeatMixin):
                 asset_name = asset.name
                 asset_type = self.get_asset_from_asset_name(asset_name).asset_type
 
-                is_asset_energy_source = False
-                if (asset_type == "HeatProducer"
-                    or asset_type == "GenericProducer"
-                    or asset_type == "ResidualHeatSource"
-                    or asset_type == "GeothermalSource"
-                    or asset_type == "ResidualHeatSource"
-                    or asset_type == "GasHeater"
-                ):
-                    is_asset_energy_source = True
+                asset_placement_var = self._asset_aggregation_count_var_map[asset.name]
+                placed = np.round(results[asset_placement_var][0]) >= 1.0
 
-                if asset_type == "Joint":
-                    continue
-                try:
-                    energy_breakdown[asset_type] += np.sum(results[f"{asset_name}.Heat_source"])
-                except KeyError:
+                if placed:
+                    is_asset_opex_included = False
+                    if (
+                        asset_type == "HeatProducer"
+                        or asset_type == "GenericProducer"
+                        or asset_type == "ResidualHeatSource"
+                        or asset_type == "GeothermalSource"
+                        or asset_type == "ResidualHeatSource"
+                        or asset_type == "GasHeater"
+                        or asset_type == "HeatStorage"
+                    ):
+                        is_asset_opex_included = True
+                        is_at_least_asset_opex_included = True
+
+                    if asset_type == "Joint":
+                        continue
                     try:
-                        energy_breakdown[asset_type] = np.sum(results[f"{asset_name}.Heat_source"])
+                        energy_breakdown[asset_type] += np.sum(results[f"{asset_name}.Heat_source"])
                     except KeyError:
                         try:
-                            energy_breakdown[asset_type] += np.sum(
-                                results[f"{asset_name}.Secondary_heat"]
+                            energy_breakdown[asset_type] = np.sum(
+                                results[f"{asset_name}.Heat_source"]
                             )
                         except KeyError:
                             try:
-                                energy_breakdown[asset_type] = np.sum(
-                                    results[f"{asset_name}.Secondary_heat"])
-                            except: # maybe give warning to user?
-                                pass
-                # Here we make both the KPIs for the cost breakdown per asset and aggregated
-                investment = max(results[self._asset_investment_cost_map[asset_name]][0], 1.0)
-                installation = max(results[self._asset_installation_cost_map[asset_name]][0], 1.0)
-                var_opex = max(
-                    results[self._asset_variable_operational_cost_map[asset_name]][0],
-                    1.0
-                )
-                fix_opex = max(results[self._asset_fixed_operational_cost_map[asset_name]][0], 1.0)
-                total_investment += investment
-                total_installation += installation
-                total_variable_opex += var_opex
-                total_fixed_opex += fix_opex
+                                energy_breakdown[asset_type] += np.sum(
+                                    results[f"{asset_name}.Secondary_heat"]
+                                )
+                            except KeyError:
+                                try:
+                                    energy_breakdown[asset_type] = np.sum(
+                                        results[f"{asset_name}.Secondary_heat"]
+                                    )
+                                except KeyError:
+                                    pass
 
-                # Here we add KPIs to the subarea which allows to visualize them by hoovering over
-                # it with the mouse
+                    # Create KPIs by using applicable costs for the specific asset
+                    area_investment_cost += max(
+                        results[self._asset_investment_cost_map[asset_name]][0], 1.0
+                    )
+                    area_installation_cost += max(
+                        results[self._asset_installation_cost_map[asset_name]][0], 1.0
+                    )
+                    if is_asset_opex_included:
+                        area_variable_opex_cost += max(
+                            results[self._asset_variable_operational_cost_map[asset_name]][0], 1.0
+                        )
+                        area_fixed_opex_cost += max(
+                            results[self._asset_fixed_operational_cost_map[asset_name]][0], 1.0
+                        )
+
+            # Here we add KPIs to the polygon area which allows to visualize them by hoovering over
+            # it with the mouse
+            kpis.kpi.append(
+                esdl.DoubleKPI(
+                    value=area_investment_cost / 1.0e6,
+                    name="Investment",
+                    quantityAndUnit=esdl.esdl.QuantityAndUnitType(
+                        physicalQuantity=esdl.PhysicalQuantityEnum.COST,
+                        unit=esdl.UnitEnum.EURO,
+                        multiplier=esdl.MultiplierEnum.MEGA,
+                    ),
+                )
+            )
+            kpis.kpi.append(
+                esdl.DoubleKPI(
+                    value=area_installation_cost / 1.0e6,
+                    name="Installation",
+                    quantityAndUnit=esdl.esdl.QuantityAndUnitType(
+                        physicalQuantity=esdl.PhysicalQuantityEnum.COST,
+                        unit=esdl.UnitEnum.EURO,
+                        multiplier=esdl.MultiplierEnum.MEGA,
+                    ),
+                )
+            )
+
+            if is_at_least_asset_opex_included:
                 kpis.kpi.append(
                     esdl.DoubleKPI(
-                        value=investment,
-                        name="Investment",
+                        value=area_variable_opex_cost / 1.0e6,
+                        name="Variable OPEX",
                         quantityAndUnit=esdl.esdl.QuantityAndUnitType(
                             physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                            unit=esdl.UnitEnum.EURO
-                        )
+                            unit=esdl.UnitEnum.EURO,
+                            multiplier=esdl.MultiplierEnum.MEGA,
+                        ),
                     )
                 )
                 kpis.kpi.append(
                     esdl.DoubleKPI(
-                        value=installation,
-                        name="Installation",
+                        value=area_fixed_opex_cost / 1.0e6,
+                        name="Fixed OPEX",
                         quantityAndUnit=esdl.esdl.QuantityAndUnitType(
                             physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                            unit=esdl.UnitEnum.EURO
-                        )
+                            unit=esdl.UnitEnum.EURO,
+                            multiplier=esdl.MultiplierEnum.MEGA,
+                        ),
                     )
-                )                
+                )
 
-                if is_asset_energy_source:
-                    kpis.kpi.append(
-                        esdl.DoubleKPI(
-                            value=var_opex,
-                            name="Variable OPEX",
-                            quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                                physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                                unit=esdl.UnitEnum.EURO
-                            )
-                        )
-                    )
-                    kpis.kpi.append(
-                        esdl.DoubleKPI(
-                            value=fix_opex,
-                            name="Fixed OPEX",
-                            quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                                physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                                unit=esdl.UnitEnum.EURO
-                            )
-                        )
-                    )
-                # Here We add the full list of assets with their cost breakdown to give a table of cost breakdown in the KPI window
-                # Note that we use the top level area here! Only top level area KPIs are put in the KPI window
-                # ??
-                # if is_asset_energy_source:
-                #     kpis_top_level.kpi.append(
-                #         esdl.DistributionKPI(
-                #             name="Asset cost breakdown [EUR]",
-                #             distribution=esdl.StringLabelDistribution(
-                #                 stringItem=[
-                #                     esdl.StringItem(label="Installation", value=installation),
-                #                     esdl.StringItem(label="Investment", value=investment),
-                #                     esdl.StringItem(label="Variable OPEX", value=var_opex),
-                #                     esdl.StringItem(label="Fixed OPEX", value=fix_opex)
-                #                 ]
-                #             ),
-                #             quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                #                 physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                #                 unit=esdl.UnitEnum.EURO
-                #             )
-                #         )
-                #     )
-                # else:
-                kpi_name = f"{subarea.name}: Asset cost breakdown [EUR]"
+            # Top level KPIs: Cost breakdown in a polygon area (for all assest grouped together)
+            kpi_name = f"{subarea.name}: Asset cost breakdown [EUR]"
+            if is_asset_opex_included:
                 kpis_top_level.kpi.append(
                     esdl.DistributionKPI(
                         name=kpi_name,
                         distribution=esdl.StringLabelDistribution(
                             stringItem=[
-                                esdl.StringItem(label="Installation", value=installation),
-                                esdl.StringItem(label="Investment", value=investment),
-                                esdl.StringItem(label="Variable OPEX", value=var_opex),
-                                esdl.StringItem(label="Fixed OPEX", value=fix_opex)
+                                esdl.StringItem(label="Installation", value=area_installation_cost),
+                                esdl.StringItem(label="Investment", value=area_investment_cost),
+                                esdl.StringItem(
+                                    label="Variable OPEX", value=area_variable_opex_cost
+                                ),
+                                esdl.StringItem(label="Fixed OPEX", value=area_fixed_opex_cost),
                             ]
                         ),
                         quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                            physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                            unit=esdl.UnitEnum.EURO
-                        )
+                            physicalQuantity=esdl.PhysicalQuantityEnum.COST, unit=esdl.UnitEnum.EURO
+                        ),
+                    )
+                )
+            else:
+                kpis_top_level.kpi.append(
+                    esdl.DistributionKPI(
+                        name=kpi_name,
+                        distribution=esdl.StringLabelDistribution(
+                            stringItem=[
+                                esdl.StringItem(label="Installation", value=area_installation_cost),
+                                esdl.StringItem(label="Investment", value=area_investment_cost),
+                            ]
+                        ),
+                        quantityAndUnit=esdl.esdl.QuantityAndUnitType(
+                            physicalQuantity=esdl.PhysicalQuantityEnum.COST, unit=esdl.UnitEnum.EURO
+                        ),
                     )
                 )
 
-                
             # Here we add a distribution KPI to the subarea to which gives a piechart
             # !!!!!!!!!!!!!!! This will only work if the source is in the area?
-            # Still to be resolved
-            kpis.kpi.append(
-                esdl.DistributionKPI(
-                    name="Energy breakdown ?",
-                    distribution=esdl.StringLabelDistribution(
-                        stringItem=[
-                            esdl.StringItem(label=key, value=value) for key,
-                            value in energy_breakdown.items()
-                        ]
-                    )
-                )
-            )
+            # TODO: Still to be resolved since piecharts are still a work in progress in mapeditor
+            # kpis.kpi.append(
+            #     esdl.DistributionKPI(
+            #         name="Energy breakdown ?",
+            #         distribution=esdl.StringLabelDistribution(
+            #             stringItem=[
+            #                 esdl.StringItem(label=key, value=value) for key,
+            #                 value in energy_breakdown.items()
+            #             ]
+            #         )
+            #     )
+            # )
             subarea.KPIs = kpis
-
-# --------------------------------------------------------------------------------------------------
+        # end KPIs
+        # ------------------------------------------------------------------------------------------
         # Placement
         for _, attributes in self.esdl_assets.items():
             name = attributes.name
@@ -639,10 +661,6 @@ class ScenarioOutput(HeatMixin):
 
         self.__optimized_energy_system_handler = esh
         self.optimized_esdl_string = esh.to_string()
-# ------------------------------------------------------------------------------------------------
-        # Maybe to KPIs after items have been deleted???
- 
-# ------------------------------------------------------------------------------------------
 
         if self.esdl_string is None:
             if optimizer_sim:

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -439,19 +439,17 @@ class ScenarioOutput(HeatMixin):
                                     pass
 
                     # Create KPIs by using applicable costs for the specific asset
-                    area_investment_cost += max(
-                        results[self._asset_investment_cost_map[asset_name]][0], 1.0
-                    )
-                    area_installation_cost += max(
-                        results[self._asset_installation_cost_map[asset_name]][0], 1.0
-                    )
+                    area_investment_cost += results[self._asset_investment_cost_map[asset_name]][0]
+                    area_installation_cost += results[
+                        self._asset_installation_cost_map[asset_name]
+                    ][0]
                     if is_asset_opex_included:
-                        area_variable_opex_cost += max(
-                            results[self._asset_variable_operational_cost_map[asset_name]][0], 1.0
-                        )
-                        area_fixed_opex_cost += max(
-                            results[self._asset_fixed_operational_cost_map[asset_name]][0], 1.0
-                        )
+                        area_variable_opex_cost += results[
+                            self._asset_variable_operational_cost_map[asset_name]
+                        ][0]
+                        area_fixed_opex_cost += results[
+                            self._asset_fixed_operational_cost_map[asset_name]
+                        ][0]
 
             # Here we add KPIs to the polygon area which allows to visualize them by hoovering over
             # it with the mouse


### PR DESCRIPTION
Developed KPIs which are now written to the optimized results (esdl) file so that they can be viewed in the mapeditor. The KPIs are split into 2 mains groups:
1. Overall network KPIs
2. KPIs per polygon area drawn in the mapeditor

Note:
- Test case still to be developed 
- The code was manually tested with the grow_workflow (test_end_scenario_sizing.py), which was applied to test_case_small_network_ates_buffer_optional_assets. The latter was modified by adding a polygon area for each heating demand, and 1 polygon area for the 2 heat producers.  This modified input esdl file has not been committed to this work, but it can be found at the following link:

[test_case_small_network_with_ates_with_buffer_all_optional.zip](https://github.com/Nieuwe-Warmte-Nu/rtc-tools-heat-network/files/12608110/test_case_small_network_with_ates_with_buffer_all_optional.zip)
