### PR TITLE
9 poc change ates to be connected as a demand like a buffer

### DIFF
--- a/src/rtctools_heat_network/heat_mixin.py
+++ b/src/rtctools_heat_network/heat_mixin.py
@@ -2758,7 +2758,7 @@ class HeatMixin(_HeadLossMixin, BaseComponentTypeMixin, CollocatedIntegratedOpti
             rho = parameters[f"{a}.rho"]
             dt = parameters[f"{a}.dT"]
 
-            discharge = self.state(f"{a}.HeatIn.Q")
+            discharge = self.state(f"{a}.Q")
             # Note that `heat_hot` can be negative for the buffer; in that case we
             # are extracting heat from it.
             heat_ates = self.state(f"{a}.Heat_ates")
@@ -2781,18 +2781,18 @@ class HeatMixin(_HeadLossMixin, BaseComponentTypeMixin, CollocatedIntegratedOpti
             constraints.append(
                 (
                     (heat_ates - cp * rho * dt * discharge) / constraint_nominal,
+                    -np.inf,
                     0.0,
-                    np.inf,
                 )
             )
 
             constraint_nominal = (heat_nominal * cp * rho * dt * q_nominal) ** 0.5
             constraints.append(
                 (
-                    (heat_ates - cp * rho * dt * discharge - (1 - is_ates_charging) * big_m)
+                    (heat_ates - cp * rho * dt * discharge + (1 - is_ates_charging) * big_m)
                     / constraint_nominal,
-                    -np.inf,
                     0.0,
+                    np.inf,
                 )
             )
 

--- a/src/rtctools_heat_network/heat_mixin.py
+++ b/src/rtctools_heat_network/heat_mixin.py
@@ -2749,8 +2749,8 @@ class HeatMixin(_HeadLossMixin, BaseComponentTypeMixin, CollocatedIntegratedOpti
         bounds = self.bounds()
 
         for a, (
-            (_cold_pipe, _cold_pipe_orientation),
             (hot_pipe, _hot_pipe_orientation),
+            (_cold_pipe, _cold_pipe_orientation),
         ) in self.heat_network_topology.ates.items():
             heat_nominal = parameters[f"{a}.Heat_nominal"]
             q_nominal = self.variable_nominal(f"{a}.Q")
@@ -2770,7 +2770,7 @@ class HeatMixin(_HeadLossMixin, BaseComponentTypeMixin, CollocatedIntegratedOpti
             # the constraints with a boolean. Note that `discharge` and `heat_hot`
             # are guaranteed to have the same sign.
             flow_dir_var = self.__pipe_to_flow_direct_map[hot_pipe]
-            is_ates_charging = 1 - self.state(flow_dir_var)
+            is_ates_charging = self.state(flow_dir_var)
 
             big_m = self.__get_abs_max_bounds(
                 *self.merge_bounds(bounds[f"{a}.HeatIn.Heat"], bounds[f"{a}.HeatOut.Heat"])

--- a/src/rtctools_heat_network/modelica_component_type_mixin.py
+++ b/src/rtctools_heat_network/modelica_component_type_mixin.py
@@ -268,9 +268,9 @@ class ModelicaComponentTypeMixin(BaseComponentTypeMixin):
                 assert pipe_w_orientation[0] in pipes_set
 
                 if k == "Out":
-                    assert self.is_hot_pipe(pipe_w_orientation[0])
-                else:
                     assert self.is_cold_pipe(pipe_w_orientation[0])
+                else:
+                    assert self.is_hot_pipe(pipe_w_orientation[0])
 
                 ates_connections[a].append(pipe_w_orientation)
 

--- a/src/rtctools_heat_network/pycml/component_library/heat/ates.py
+++ b/src/rtctools_heat_network/pycml/component_library/heat/ates.py
@@ -60,7 +60,7 @@ class ATES(HeatTwoPort, BaseAsset):
 
         # Heat stored in the ates
         self.add_equation(
-            (self.der(self.Stored_heat) + self.Heat_ates + self.Heat_loss)
+            (self.der(self.Stored_heat) - self.Heat_ates + self.Heat_loss)
             / self._heat_loss_eq_nominal_ates
         )
         self.add_equation(

--- a/src/rtctools_heat_network/pycml/component_library/heat/ates.py
+++ b/src/rtctools_heat_network/pycml/component_library/heat/ates.py
@@ -45,6 +45,7 @@ class ATES(HeatTwoPort, BaseAsset):
             min=0.0,
             nominal=self._nominal_stored_heat,
         )
+        self.add_variable(Variable, "Q", nominal=self.Q_nominal)
         # For nicer constraint coefficient scaling, we shift a bit more error into
         # the state vector entry of `Heat_loss`. In other words, with a factor of
         # 10.0, we aim for a state vector entry of ~0.1 (instead of 1.0)
@@ -57,6 +58,7 @@ class ATES(HeatTwoPort, BaseAsset):
         self._heat_loss_eq_nominal_ates = (self.Heat_nominal * self._nominal_heat_loss) ** 0.5
 
         self.add_equation(self.HeatIn.Q - self.HeatOut.Q)
+        self.add_equation(self.Q - self.HeatOut.Q)
 
         # Heat stored in the ates
         self.add_equation(

--- a/src/rtctools_heat_network/pycml/component_library/heat/ates.py
+++ b/src/rtctools_heat_network/pycml/component_library/heat/ates.py
@@ -67,6 +67,6 @@ class ATES(HeatTwoPort, BaseAsset):
             (self.Heat_loss - self.Stored_heat * self.heat_loss_coeff) / self._nominal_heat_loss
         )
         self.add_equation(
-            (self.HeatOut.Heat - (self.HeatIn.Heat + self.Heat_ates)) / self.Heat_nominal
+            (self.HeatIn.Heat - (self.HeatOut.Heat + self.Heat_ates)) / self.Heat_nominal
         )
         self.add_equation((self.Heat_flow - self.Heat_ates) / self.Heat_nominal)

--- a/src/rtctools_heat_network/pycml/component_library/heat/buffer.py
+++ b/src/rtctools_heat_network/pycml/component_library/heat/buffer.py
@@ -63,6 +63,7 @@ class Buffer(HeatTwoPort, BaseAsset):
             max=self.max_stored_heat,
             nominal=self._nominal_stored_heat,
         )
+        self.add_variable(Variable, "Q", nominal=self.Q_nominal)
         # For nicer constraint coefficient scaling, we shift a bit more error into
         # the state vector entry of `Heat_loss`. In other words, with a factor of
         # 10.0, we aim for a state vector entry of ~0.1 (instead of 1.0)
@@ -76,6 +77,7 @@ class Buffer(HeatTwoPort, BaseAsset):
         self._heat_loss_eq_nominal_buf = (self.Heat_nominal * self._nominal_heat_loss) ** 0.5
 
         self.add_equation(self.HeatIn.Q - self.HeatOut.Q)
+        self.add_equation(self.Q - self.HeatOut.Q)
 
         # Heat stored in the buffer
         self.add_equation(

--- a/tests/models/test_case_small_network_ates_buffer_optional_assets/model/test_case_small_network_with_ates_with_buffer_all_optional.esdl
+++ b/tests/models/test_case_small_network_ates_buffer_optional_assets/model/test_case_small_network_with_ates_with_buffer_all_optional.esdl
@@ -1,500 +1,512 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" id="7ac09231-ce60-4c24-8338-9c0317695ba4_with_return_network" name="Untitled EnergySystem with return network" description="" esdlVersion="v2210" version="13">
+<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" name="Untitled EnergySystem with return network" id="7ac09231-ce60-4c24-8338-9c0317695ba4_with_return_network" description="" esdlVersion="v2210" version="14">
   <energySystemInformation xsi:type="esdl:EnergySystemInformation" id="e64737d9-d772-4723-b092-a0b397ac00b3">
     <carriers xsi:type="esdl:Carriers" id="9dff13b9-77cd-4b99-8777-6b7680a155b6">
       <carrier xsi:type="esdl:HeatCommodity" id="7b32e287-d775-480c-b317-64ffdacf12c9" name="Heat" supplyTemperature="70.0"/>
-      <carrier xsi:type="esdl:HeatCommodity" id="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Heat_ret" returnTemperature="40.0"/>
+      <carrier xsi:type="esdl:HeatCommodity" returnTemperature="40.0" id="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Heat_ret"/>
     </carriers>
   </energySystemInformation>
   <instance xsi:type="esdl:Instance" id="f852b941-99fe-487b-a20d-01beff9e7c43" name="Untitled Instance">
     <area xsi:type="esdl:Area" id="f4acc7ef-a37d-43b7-87cb-8af5b82e3fed" name="Untitled Area">
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_1" id="c2d77abc-1656-4722-8508-7c64574e04ef" power="10000000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04198588944146" lon="4.3088722229003915"/>
+        <port xsi:type="esdl:InPort" connectedTo="1dfdc172-9359-435a-8153-0a657932223a" id="2a873195-fa6b-4250-8519-046f040fedb7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="ef74ea8c-89b4-42e0-a98c-411860876c1a" connectedTo="18ce6906-595c-45e4-acf0-e07f7d7648c6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="d8a67243-4e4e-43f8-9801-fd4579c0eddf">
-          <installationCosts xsi:type="esdl:SingleValue" id="accd84bc-d3ed-4528-a1ff-f906c48991a1" value="1000000.0">
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="accd84bc-d3ed-4528-a1ff-f906c48991a1">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="ae8b81fb-857b-4280-9e91-919dd1c7675e" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.3088722229003915" CRS="WGS84" lat="52.04198588944146"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="1dfdc172-9359-435a-8153-0a657932223a" name="In" id="2a873195-fa6b-4250-8519-046f040fedb7"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="18ce6906-595c-45e4-acf0-e07f7d7648c6" name="Out" id="ef74ea8c-89b4-42e0-a98c-411860876c1a"/>
       </asset>
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_2" id="9352d984-0e21-4af6-9c5f-91f984abfcfd" power="10000000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04002590369568" lon="4.310610294342042"/>
+        <port xsi:type="esdl:InPort" connectedTo="53a54448-abdb-41ab-a53e-498556062216" id="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" connectedTo="d126f79e-c43e-4d9d-a7ce-8f58be634695" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="7d95dc58-02b0-49cf-a7a7-5623fffb4079">
-          <installationCosts xsi:type="esdl:SingleValue" id="c33af629-6fc5-4d7c-9ac4-5b1e0db295a5" value="1000000.0">
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="c33af629-6fc5-4d7c-9ac4-5b1e0db295a5">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="89301826-acf3-4fec-b03c-7db277de004a" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.310610294342042" CRS="WGS84" lat="52.04002590369568"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="53a54448-abdb-41ab-a53e-498556062216" name="In" id="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="d126f79e-c43e-4d9d-a7ce-8f58be634695" name="Out" id="bf6e0b6b-baac-468b-a9ba-f8397babf5d6"/>
       </asset>
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_3" id="e295a155-3fab-4ab1-925d-7bdb50094f48" power="10000000.0">
+        <geometry xsi:type="esdl:Point" lat="52.03796848613761" lon="4.312646090984345"/>
+        <port xsi:type="esdl:InPort" connectedTo="16b1337c-5970-4eb4-90d3-e52d514a13df" id="770022e6-3e71-4e51-8544-0dba86c46a5b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="9c025b19-57d1-43a8-b2e8-db3e684756f2" connectedTo="5cd0f2e0-d456-4909-a81c-4b312b1be857" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="3d07b171-f65b-413d-9090-2d1cd578a488">
-          <installationCosts xsi:type="esdl:SingleValue" id="ae1d6cd8-2990-4a77-a74c-65eb9c93b084" value="1000000.0">
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="ae1d6cd8-2990-4a77-a74c-65eb9c93b084">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="7feb28ca-bfb8-4c0d-b1b5-ab1b397e394c" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.312646090984345" lat="52.03796848613761"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="16b1337c-5970-4eb4-90d3-e52d514a13df" name="In" id="770022e6-3e71-4e51-8544-0dba86c46a5b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="5cd0f2e0-d456-4909-a81c-4b312b1be857" name="Out" id="9c025b19-57d1-43a8-b2e8-db3e684756f2"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe1" id="Pipe1" diameter="DN450" related="Pipe1_ret" length="245.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe1_ret" diameter="DN450" name="Pipe1" length="245.7" id="Pipe1" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="52.04469805119214" lon="4.310052394866944"/>
+          <point xsi:type="esdl:Point" lat="52.04274148388849" lon="4.311720728874207"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="45bfc7d0-ef59-4f49-b37a-867b18e04b86" id="b462d564-a8c0-4ae0-a4af-36958f2455ea" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="66590f96-a397-4d6f-9cfb-e7d34232cad6" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="ec2d740c-2f13-4b70-a1bb-6e4a561414c2">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe2_ret" diameter="DN450" name="Pipe2" length="195.4" id="Pipe2" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.310052394866944" lat="52.04469805119214"/>
-          <point xsi:type="esdl:Point" lon="4.311720728874207" lat="52.04274148388849"/>
+          <point xsi:type="esdl:Point" lat="52.04271178827801" lon="4.311629533767701"/>
+          <point xsi:type="esdl:Point" lat="52.04202218466326" lon="4.309000968933106"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="45bfc7d0-ef59-4f49-b37a-867b18e04b86" name="In" id="b462d564-a8c0-4ae0-a4af-36958f2455ea"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="66590f96-a397-4d6f-9cfb-e7d34232cad6"/>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="5f65520d-61ee-4f68-8002-271f48f1daee" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="1dfdc172-9359-435a-8153-0a657932223a" connectedTo="2a873195-fa6b-4250-8519-046f040fedb7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe2" id="Pipe2" diameter="DN450" related="Pipe2_ret" length="195.4" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="c8140b3b-99dc-4ee0-b034-1050b4fd1946">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe3_ret" diameter="DN450" name="Pipe3" length="241.6" id="Pipe3" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.311629533767701" lat="52.04271178827801"/>
-          <point xsi:type="esdl:Point" lon="4.309000968933106" lat="52.04202218466326"/>
+          <point xsi:type="esdl:Point" lat="52.042708488764504" lon="4.311758279800416"/>
+          <point xsi:type="esdl:Point" lat="52.04078483093156" lon="4.31339979171753"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="5f65520d-61ee-4f68-8002-271f48f1daee"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="2a873195-fa6b-4250-8519-046f040fedb7" name="Out" id="1dfdc172-9359-435a-8153-0a657932223a"/>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="578ec414-3f11-430e-a893-60ea77848ff5" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" connectedTo="e0adf80a-b6f3-4c12-a439-dab4e555202a" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe3" id="Pipe3" diameter="DN450" related="Pipe3_ret" length="241.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="883afc13-098e-47b4-aa30-ae3c3e25f9b1">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe4_ret" diameter="DN450" name="Pipe4" length="189.7" id="Pipe4" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.311758279800416" lat="52.042708488764504"/>
-          <point xsi:type="esdl:Point" lon="4.31339979171753" lat="52.04078483093156"/>
+          <point xsi:type="esdl:Point" lat="52.04076173333622" lon="4.313324689865113"/>
+          <point xsi:type="esdl:Point" lat="52.04007209963487" lon="4.310787320137025"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="578ec414-3f11-430e-a893-60ea77848ff5"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="e0adf80a-b6f3-4c12-a439-dab4e555202a" name="Out" id="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2"/>
+        <port xsi:type="esdl:InPort" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" id="4b92e418-4ca6-4765-85ab-ce30f4127bf0" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="53a54448-abdb-41ab-a53e-498556062216" connectedTo="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe4" id="Pipe4" diameter="DN450" related="Pipe4_ret" length="189.7" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="b1dd0427-f8ca-4525-8192-8a8954f2be1c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe5_ret" diameter="DN450" name="Pipe5" length="244.6" id="Pipe5" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.313324689865113" lat="52.04076173333622"/>
-          <point xsi:type="esdl:Point" lon="4.310787320137025" lat="52.04007209963487"/>
+          <point xsi:type="esdl:Point" lat="52.04073863572898" lon="4.313453435897828"/>
+          <point xsi:type="esdl:Point" lat="52.03879839410938" lon="4.315137863159181"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" name="In" id="4b92e418-4ca6-4765-85ab-ce30f4127bf0"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" name="Out" id="53a54448-abdb-41ab-a53e-498556062216"/>
+        <port xsi:type="esdl:InPort" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" id="d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="8f1bea52-e322-4d34-ad43-7d1e97243d62" connectedTo="1cb923b5-2a69-46d9-874c-68d552ef5576" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe5" id="Pipe5" diameter="DN450" related="Pipe5_ret" length="244.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="d9132301-1f49-4c31-b38f-4e650c18a984">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe6_ret" diameter="DN450" name="Pipe6" length="176.6" id="Pipe6" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.313453435897828" lat="52.04073863572898"/>
-          <point xsi:type="esdl:Point" lon="4.315137863159181" lat="52.03879839410938"/>
+          <point xsi:type="esdl:Point" lat="52.03875219685389" lon="4.315094947814942"/>
+          <point xsi:type="esdl:Point" lat="52.03801303427292" lon="4.312809705734254"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" name="In" id="d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="1cb923b5-2a69-46d9-874c-68d552ef5576" name="Out" id="8f1bea52-e322-4d34-ad43-7d1e97243d62"/>
+        <port xsi:type="esdl:InPort" connectedTo="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" id="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="16b1337c-5970-4eb4-90d3-e52d514a13df" connectedTo="770022e6-3e71-4e51-8544-0dba86c46a5b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe6" id="Pipe6" diameter="DN450" related="Pipe6_ret" length="176.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="762aeec6-ac5d-4e54-b32f-3da929bd6713">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.315094947814942" lat="52.03875219685389"/>
-          <point xsi:type="esdl:Point" lon="4.312809705734254" lat="52.03801303427292"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" name="In" id="7f162a30-7e41-4d7f-b011-ffcf4c1651f8"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="770022e6-3e71-4e51-8544-0dba86c46a5b" name="Out" id="16b1337c-5970-4eb4-90d3-e52d514a13df"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
-          </component>
-        </material>
       </asset>
-      <asset xsi:type="esdl:HeatProducer" state="OPTIONAL" power="3000000.0" name="HeatProducer_1" id="324b0371-b738-4f55-a978-3306ee81638c">
+      <asset xsi:type="esdl:HeatProducer" power="3000000.0" name="HeatProducer_1" id="324b0371-b738-4f55-a978-3306ee81638c" state="OPTIONAL">
+        <geometry xsi:type="esdl:Point" lat="52.04476403847825" lon="4.309977293014527"/>
+        <port xsi:type="esdl:OutPort" id="45bfc7d0-ef59-4f49-b37a-867b18e04b86" connectedTo="b462d564-a8c0-4ae0-a4af-36958f2455ea" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <port xsi:type="esdl:InPort" connectedTo="e31e12c2-8f80-4aed-9e4b-918445a32996" id="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
         <costInformation xsi:type="esdl:CostInformation" id="28e9b853-e407-49b0-be66-1572c12dc811">
-          <investmentCosts xsi:type="esdl:SingleValue" id="b6c85259-9211-417f-b9db-89fb473f2f1c" value="100000.0">
+          <investmentCosts xsi:type="esdl:SingleValue" value="100000.0" id="b6c85259-9211-417f-b9db-89fb473f2f1c">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="47fcbff2-f0f1-48d9-b7c1-7e34a90b1539" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="ccba43a5-c4c8-4818-a339-762b3385f562" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="6924031c-0548-4b33-a341-3d03c5c2b5a0" description="Cost in EUR"/>
-          </installationCosts>
-          <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="b90c659f-4d87-4402-b042-90a7594e7016" value="15.0">
+          <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" value="15.0" id="b90c659f-4d87-4402-b042-90a7594e7016">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="0d948406-7864-4eff-bc65-7670533bf18b" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </variableOperationalAndMaintenanceCosts>
+          <installationCosts xsi:type="esdl:SingleValue" value="100000.0" id="ccba43a5-c4c8-4818-a339-762b3385f562">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="6924031c-0548-4b33-a341-3d03c5c2b5a0" description="Cost in EUR"/>
+          </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.309977293014527" lat="52.04476403847825"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="b462d564-a8c0-4ae0-a4af-36958f2455ea" name="Out" id="45bfc7d0-ef59-4f49-b37a-867b18e04b86"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="e31e12c2-8f80-4aed-9e4b-918445a32996" name="In" id="ba9ca084-b71f-42a3-884a-f2f2b3ae4265"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_1" id="f96d02d7-19d1-4a0b-8869-2d180f39b7e6">
-        <geometry xsi:type="esdl:Point" lon="4.311695247888566" CRS="WGS84" lat="52.042720861938854"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="66590f96-a397-4d6f-9cfb-e7d34232cad6 22016bf5-c6c4-4b98-8b96-559e9209319b f966bade-1fad-453f-8ec2-4062ec70bc7b" name="In" id="51852861-aeeb-461f-b8ec-08f000abc6dd"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="5f65520d-61ee-4f68-8002-271f48f1daee 578ec414-3f11-430e-a893-60ea77848ff5 2e672d8b-ee9b-4c8b-8357-58ea984ae6be" name="Out" id="c0eac4db-f5da-47f3-8202-8438d000bd32"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.042720861938854" lon="4.311695247888566"/>
+        <port xsi:type="esdl:InPort" connectedTo="66590f96-a397-4d6f-9cfb-e7d34232cad6 f966bade-1fad-453f-8ec2-4062ec70bc7b" id="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="c0eac4db-f5da-47f3-8202-8438d000bd32" connectedTo="5f65520d-61ee-4f68-8002-271f48f1daee 578ec414-3f11-430e-a893-60ea77848ff5 2e672d8b-ee9b-4c8b-8357-58ea984ae6be c7ad4fce-efbb-4b30-9508-f71a4356ca2d" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_2" id="d74db9ba-b86c-486a-8911-3ff368ae63a3">
-        <geometry xsi:type="esdl:Point" lon="4.313372969627381" CRS="WGS84" lat="52.04075678384997"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" name="In" id="e0adf80a-b6f3-4c12-a439-dab4e555202a"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="4b92e418-4ca6-4765-85ab-ce30f4127bf0 d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" name="Out" id="ed75b210-6b5a-488e-8a8d-efe570c84990"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04075678384997" lon="4.313372969627381"/>
+        <port xsi:type="esdl:InPort" connectedTo="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" id="e0adf80a-b6f3-4c12-a439-dab4e555202a" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="ed75b210-6b5a-488e-8a8d-efe570c84990" connectedTo="4b92e418-4ca6-4765-85ab-ce30f4127bf0 d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_3" id="da2f12dc-0b74-4719-bc50-18d847524db3">
-        <geometry xsi:type="esdl:Point" lon="4.315127134323121" CRS="WGS84" lat="52.038770345781394"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="8f1bea52-e322-4d34-ad43-7d1e97243d62" name="In" id="1cb923b5-2a69-46d9-874c-68d552ef5576"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" name="Out" id="a02e41ab-99f8-46d3-b2d1-be44aa5b7914"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.038770345781394" lon="4.315127134323121"/>
+        <port xsi:type="esdl:InPort" connectedTo="8f1bea52-e322-4d34-ad43-7d1e97243d62" id="1cb923b5-2a69-46d9-874c-68d552ef5576" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" connectedTo="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
-      <asset xsi:type="esdl:ATES" state="OPTIONAL" maxChargeRate="11610000.0" name="ATES_033c" wellDistance="150.0" salinity="10000.0" aquiferPermeability="10000.0" aquiferNetToGross="1.0" aquiferThickness="45.0" maxDischargeRate="11610000.0" wellCasingSize="13.0" id="033c2598-5c1a-48b7-93b1-c746b81819ff" aquiferAnisotropy="4.0" aquiferPorosity="0.3" aquiferMidTemperature="17.0" aquiferTopDepth="300.0">
-        <geometry xsi:type="esdl:Point" lon="4.314751625061036" CRS="WGS84" lat="52.04364884025295"/>
-        <dataSource xsi:type="esdl:DataSource" name="WarmingUp factsheet: HT-ATES (high)" description="This data was generated using the 'kosten_per_asset.xslx' file in the 'Kentallen' directory of WarmingUp project 1D" attribution=""/>
+      <asset xsi:type="esdl:ATES" aquiferNetToGross="1.0" name="ATES_033c" aquiferThickness="45.0" state="OPTIONAL" maxDischargeRate="11610000.0" wellCasingSize="13.0" aquiferAnisotropy="4.0" aquiferPorosity="0.3" aquiferMidTemperature="17.0" aquiferTopDepth="300.0" id="033c2598-5c1a-48b7-93b1-c746b81819ff" wellDistance="150.0" maxChargeRate="11610000.0" salinity="10000.0" aquiferPermeability="10000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04364884025295" lon="4.314751625061036"/>
+        <dataSource xsi:type="esdl:DataSource" description="This data was generated using the 'kosten_per_asset.xslx' file in the 'Kentallen' directory of WarmingUp project 1D" attribution="" name="WarmingUp factsheet: HT-ATES (high)"/>
+        <port xsi:type="esdl:InPort" connectedTo="e15db059-ab19-4483-9911-7a37f0c08e42" id="33a9041b-dd75-42c0-94a3-584c5e374927" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="0117d26b-8ab1-44b5-afee-51702e431e52" connectedTo="febc9c00-71c8-4b12-b005-28beaae24e7b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation">
+          <variableOperationalCosts xsi:type="esdl:SingleValue" value="6.0" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
+          </variableOperationalCosts>
           <investmentCosts xsi:type="esdl:SingleValue" value="233359.0">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a3b5cdd9-364b-4262-bce5-4658c5f1bac9" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO"/>
           </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="22528972-1920-42d8-9e0c-115f419c31d1" value="1000000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" unit="EURO" physicalQuantity="COST" description="Cost in EUR"/>
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="22528972-1920-42d8-9e0c-115f419c31d1">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
           </installationCosts>
-          <variableOperationalCosts xsi:type="esdl:SingleValue" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9" value="6.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
-          </variableOperationalCosts>
         </costInformation>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="42d7c2df-a85b-45bc-b2d9-b58f03dac573" name="In" id="33a9041b-dd75-42c0-94a3-584c5e374927"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="914cd2f7-b541-46ab-b093-a364f924a44d" name="Out" id="0117d26b-8ab1-44b5-afee-51702e431e52"/>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe7" id="Pipe7" diameter="DN450" related="Pipe7_ret" length="233.1" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="586386a5-95de-40a4-b331-e46f23d431af">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.314751625061036" lat="52.04364884025295"/>
-          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="0117d26b-8ab1-44b5-afee-51702e431e52" name="In" id="914cd2f7-b541-46ab-b093-a364f924a44d"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="22016bf5-c6c4-4b98-8b96-559e9209319b"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
-          </component>
-        </material>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_1_ret" id="6d97700c-a3d7-4127-b64c-f08ee2e308f9">
-        <geometry xsi:type="esdl:Point" lon="4.311074402665649" CRS="WGS84" lat="52.04281086202885"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="dd50e603-c87c-4cdb-82bb-486ebee77255 c8973070-0f1d-455a-83a1-845eec60de2b 42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" name="ret_port" id="2913e645-b027-429e-bf5d-22ace96a39fa"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="0431b8a0-a8d1-4375-b348-37a475add47a 6b655eb1-2b66-455f-90a3-0dd6f2844fab 8271240c-cae3-4e81-8b36-d65302a4e6b4" name="ret_port" id="7893125d-d82f-4fe8-aaea-5fb6afecc635"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04281086202885" lon="4.311074402665649"/>
+        <port xsi:type="esdl:OutPort" id="2913e645-b027-429e-bf5d-22ace96a39fa" connectedTo="dd50e603-c87c-4cdb-82bb-486ebee77255 42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:InPort" connectedTo="0431b8a0-a8d1-4375-b348-37a475add47a 6b655eb1-2b66-455f-90a3-0dd6f2844fab 8271240c-cae3-4e81-8b36-d65302a4e6b4 2b341054-a732-404f-a361-d39c4cb4e271" id="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_2_ret" id="e615c77a-bb75-411b-92c2-549efbdf8ec8">
-        <geometry xsi:type="esdl:Point" lon="4.312746245529536" CRS="WGS84" lat="52.04084678393997"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9 4b3973ab-6e4b-48af-947d-52c6d30f20ea" name="ret_port" id="a1b719cb-f735-4a30-a0d2-cf6945b3afa1"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="0650d850-58a9-45b3-8313-a3156a061988" name="ret_port" id="2dd7961b-46ce-4027-84b6-cc2684a03a7b"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04084678393997" lon="4.312746245529536"/>
+        <port xsi:type="esdl:InPort" connectedTo="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9 4b3973ab-6e4b-48af-947d-52c6d30f20ea" id="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:OutPort" id="2dd7961b-46ce-4027-84b6-cc2684a03a7b" connectedTo="0650d850-58a9-45b3-8313-a3156a061988" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_3_ret" id="a90d146f-e234-459c-974e-7867afbbb3f0">
-        <geometry xsi:type="esdl:Point" lon="4.314494347576344" CRS="WGS84" lat="52.03886034587139"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2045aca9-4e50-42ec-99de-fbcffa627a86" name="ret_port" id="f36b9767-8e64-4744-8cd0-08acb2ae873b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2b7c3acb-69a7-497d-a72f-b98db189841c" name="ret_port" id="59ccdddc-893b-4152-8bc4-0168e7e74bf3"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.03886034587139" lon="4.314494347576344"/>
+        <port xsi:type="esdl:InPort" connectedTo="2045aca9-4e50-42ec-99de-fbcffa627a86" id="f36b9767-8e64-4744-8cd0-08acb2ae873b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:OutPort" id="59ccdddc-893b-4152-8bc4-0168e7e74bf3" connectedTo="2b7c3acb-69a7-497d-a72f-b98db189841c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe1_ret" id="Pipe1_ret" diameter="DN450" related="Pipe1" length="245.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe1" diameter="DN450" name="Pipe1_ret" length="245.7" id="Pipe1_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04283148397849" lon="4.311099944779182"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04478805128214" lon="4.309437355033006"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" id="dd50e603-c87c-4cdb-82bb-486ebee77255" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="e31e12c2-8f80-4aed-9e4b-918445a32996" connectedTo="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="03c07293-f6d4-4aa6-a297-5312c4d1c27e">
-          <investmentCosts xsi:type="esdl:SingleValue" id="9b449144-d0bf-45b9-8822-15dba1d4126d" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="6dbe093f-f6dd-49b4-9d5e-a2cd578611be" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="9b449144-d0bf-45b9-8822-15dba1d4126d">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="6dbe093f-f6dd-49b4-9d5e-a2cd578611be" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.311099944779182" CRS="WGS84" lat="52.04283148397849"/>
-          <point xsi:type="esdl:Point" lon="4.309437355033006" CRS="WGS84" lat="52.04478805128214"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In_ret" id="dd50e603-c87c-4cdb-82bb-486ebee77255"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" name="Out_ret" id="e31e12c2-8f80-4aed-9e4b-918445a32996"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe2_ret" id="Pipe2_ret" diameter="DN450" related="Pipe2" length="195.4" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe2" diameter="DN450" name="Pipe2_ret" length="195.4" id="Pipe2_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04211218475326" lon="4.308378045386691"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04280178836801" lon="4.311008661644606"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="ef74ea8c-89b4-42e0-a98c-411860876c1a" id="18ce6906-595c-45e4-acf0-e07f7d7648c6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="0431b8a0-a8d1-4375-b348-37a475add47a" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="bec83070-2c51-4825-82f3-92434bd3e59c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="1c33024c-99c8-4168-b353-9f099b59eb60" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="26fdb8bf-6413-4272-a56b-b084823ac574" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="1c33024c-99c8-4168-b353-9f099b59eb60">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="26fdb8bf-6413-4272-a56b-b084823ac574" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.308378045386691" CRS="WGS84" lat="52.04211218475326"/>
-          <point xsi:type="esdl:Point" lon="4.311008661644606" CRS="WGS84" lat="52.04280178836801"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="ef74ea8c-89b4-42e0-a98c-411860876c1a" name="In_ret" id="18ce6906-595c-45e4-acf0-e07f7d7648c6"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out_ret" id="0431b8a0-a8d1-4375-b348-37a475add47a"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe3_ret" id="Pipe3_ret" diameter="DN450" related="Pipe3" length="241.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe3" diameter="DN450" name="Pipe3_ret" length="241.6" id="Pipe3_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040874831021554" lon="4.312773152370705"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.0427984888545" lon="4.3111373978948455"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="2dd7961b-46ce-4027-84b6-cc2684a03a7b" id="0650d850-58a9-45b3-8313-a3156a061988" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="6b655eb1-2b66-455f-90a3-0dd6f2844fab" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="38f2f0f7-f814-4baf-ae3a-365af1b872db">
-          <investmentCosts xsi:type="esdl:SingleValue" id="78221659-7294-4830-802c-67e38364b1f0" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="19f63b61-453d-4213-bdc6-86f65468fec9" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="78221659-7294-4830-802c-67e38364b1f0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="19f63b61-453d-4213-bdc6-86f65468fec9" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.312773152370705" CRS="WGS84" lat="52.040874831021554"/>
-          <point xsi:type="esdl:Point" lon="4.3111373978948455" CRS="WGS84" lat="52.0427984888545"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2dd7961b-46ce-4027-84b6-cc2684a03a7b" name="In_ret" id="0650d850-58a9-45b3-8313-a3156a061988"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out_ret" id="6b655eb1-2b66-455f-90a3-0dd6f2844fab"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe4_ret" id="Pipe4_ret" diameter="DN450" related="Pipe4" length="189.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe4" diameter="DN450" name="Pipe4_ret" length="189.7" id="Pipe4_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04016209972487" lon="4.310158519812684"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040851733426216" lon="4.312697980725036"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" id="d126f79e-c43e-4d9d-a7ce-8f58be634695" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="2a15456e-d23e-4064-8dee-c0588d3b05dc">
-          <investmentCosts xsi:type="esdl:SingleValue" id="0297b96a-c32c-41f8-8653-0085659dba29" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="9869b0d2-dfa3-4148-86ab-ddd1cb43b7c7" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="0297b96a-c32c-41f8-8653-0085659dba29">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="9869b0d2-dfa3-4148-86ab-ddd1cb43b7c7" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.310158519812684" CRS="WGS84" lat="52.04016209972487"/>
-          <point xsi:type="esdl:Point" lon="4.312697980725036" CRS="WGS84" lat="52.040851733426216"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" name="In_ret" id="d126f79e-c43e-4d9d-a7ce-8f58be634695"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" name="Out_ret" id="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe5_ret" id="Pipe5_ret" diameter="DN450" related="Pipe5" length="244.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe5" diameter="DN450" name="Pipe5_ret" length="244.6" id="Pipe5_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.038888394199375" lon="4.314505162850188"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040828635818976" lon="4.312826656948579"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="59ccdddc-893b-4152-8bc4-0168e7e74bf3" id="2b7c3acb-69a7-497d-a72f-b98db189841c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="4b3973ab-6e4b-48af-947d-52c6d30f20ea" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="387eb458-4e3e-4e0d-bf1c-0ca2d77aa4dd">
-          <investmentCosts xsi:type="esdl:SingleValue" id="b78ac8a7-9d0e-4603-821b-febf58b48bb3" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d6547801-0eb7-4ed4-9597-1e79cc093622" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="b78ac8a7-9d0e-4603-821b-febf58b48bb3">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d6547801-0eb7-4ed4-9597-1e79cc093622" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.314505162850188" CRS="WGS84" lat="52.038888394199375"/>
-          <point xsi:type="esdl:Point" lon="4.312826656948579" CRS="WGS84" lat="52.040828635818976"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="59ccdddc-893b-4152-8bc4-0168e7e74bf3" name="In_ret" id="2b7c3acb-69a7-497d-a72f-b98db189841c"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" name="Out_ret" id="4b3973ab-6e4b-48af-947d-52c6d30f20ea"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe6_ret" id="Pipe6_ret" diameter="DN450" related="Pipe6" length="176.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe6" diameter="DN450" name="Pipe6_ret" length="176.6" id="Pipe6_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.03810303436292" lon="4.312174575996732"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.03884219694389" lon="4.314462105124955"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="9c025b19-57d1-43a8-b2e8-db3e684756f2" id="5cd0f2e0-d456-4909-a81c-4b312b1be857" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="2045aca9-4e50-42ec-99de-fbcffa627a86" connectedTo="f36b9767-8e64-4744-8cd0-08acb2ae873b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="cbbb74ba-ba6f-4f17-a78f-3b3c07ce531d">
-          <investmentCosts xsi:type="esdl:SingleValue" id="ae5f4f5f-1323-4a3b-98c8-faca321a00c7" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="18570b20-b820-43d0-952a-b6eaf166c639" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="ae5f4f5f-1323-4a3b-98c8-faca321a00c7">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="18570b20-b820-43d0-952a-b6eaf166c639" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.312174575996732" CRS="WGS84" lat="52.03810303436292"/>
-          <point xsi:type="esdl:Point" lon="4.314462105124955" CRS="WGS84" lat="52.03884219694389"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="9c025b19-57d1-43a8-b2e8-db3e684756f2" name="In_ret" id="5cd0f2e0-d456-4909-a81c-4b312b1be857"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="f36b9767-8e64-4744-8cd0-08acb2ae873b" name="Out_ret" id="2045aca9-4e50-42ec-99de-fbcffa627a86"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe7_ret" id="Pipe7_ret" diameter="DN450" related="Pipe7" length="233.1" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="1eb6da23-b456-44fb-88a7-94ff025cee8f">
-          <investmentCosts xsi:type="esdl:SingleValue" id="9e6f7b4c-5be0-43f8-a75a-aa24c5ae0d00" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5709dcf7-d67d-437a-8d9d-6421a21b0bc0" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.311074402665649" CRS="WGS84" lat="52.04281086202885"/>
-          <point xsi:type="esdl:Point" lon="4.314133518440636" CRS="WGS84" lat="52.04373884034295"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In_ret" id="c8973070-0f1d-455a-83a1-845eec60de2b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="33a9041b-dd75-42c0-94a3-584c5e374927" name="Out_ret" id="42d7c2df-a85b-45bc-b2d9-b58f03dac573"/>
-      </asset>
-      <asset xsi:type="esdl:HeatProducer" state="OPTIONAL" power="50000000.0" name="HeatProducer_2" id="da00ddfc-cfa4-4f21-b5be-7c69d2bf53bb">
+      <asset xsi:type="esdl:HeatProducer" power="50000000.0" name="HeatProducer_2" id="da00ddfc-cfa4-4f21-b5be-7c69d2bf53bb" state="OPTIONAL">
+        <geometry xsi:type="esdl:Point" lon="4.311726093292237" CRS="WGS84" lat="52.04487621664103"/>
+        <port xsi:type="esdl:OutPort" id="886e5430-bec1-44e3-bab6-221c4518c810" connectedTo="bbfed830-071d-4d02-bddd-e709247c8337" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <port xsi:type="esdl:InPort" connectedTo="df6f89d0-7872-4891-934f-de407f6aa142" id="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
         <costInformation xsi:type="esdl:CostInformation" id="d59fe0c4-5156-4dcf-b259-6ac6855241c6">
-          <investmentCosts xsi:type="esdl:SingleValue" id="3633cd09-9f87-4d8d-a5f8-0431bab9576d" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88a009ff-0eeb-48b1-9eb3-60dba04b3e79" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="2b2f4b93-32c7-4f20-9723-5900cc76fe20" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="b0975eef-2e13-4b7f-b89a-64a47183e8cc" unit="EURO" physicalQuantity="COST" description="Cost in EUR"/>
-          </installationCosts>
-          <variableOperationalCosts xsi:type="esdl:SingleValue" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9" value="6.0">
+          <variableOperationalCosts xsi:type="esdl:SingleValue" value="6.0" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </variableOperationalCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237" CRS="WGS84"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="bbfed830-071d-4d02-bddd-e709247c8337" name="Out" id="886e5430-bec1-44e3-bab6-221c4518c810"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="df6f89d0-7872-4891-934f-de407f6aa142" name="In" id="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b"/>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_f6e5" id="f6e5a760-01d5-4341-bf15-b8d33b7bea50" diameter="DN450" length="239.7" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="22fb2e85-7a81-4371-b6ab-6d5101b8ca45">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="100000.0" id="3633cd09-9f87-4d8d-a5f8-0431bab9576d">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88a009ff-0eeb-48b1-9eb3-60dba04b3e79" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </investmentCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237"/>
-          <point xsi:type="esdl:Point" lat="52.042720861938854" lon="4.311695247888566"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="886e5430-bec1-44e3-bab6-221c4518c810" name="In" id="bbfed830-071d-4d02-bddd-e709247c8337"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="f966bade-1fad-453f-8ec2-4062ec70bc7b"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
-          </component>
-        </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_f6e5_ret" id="0db91515-418a-4bcb-9d99-9047c1ca8bdf" diameter="DN450" length="233.9" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="7cbc9c32-3d7d-44e1-ab73-598459294f0c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.04281086202885" lon="4.311074402665649"/>
-          <point xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In" id="42e9f86b-ea96-4992-bf3f-9cbae8a4a39c"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" name="Out" id="df6f89d0-7872-4891-934f-de407f6aa142"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
-          </component>
-        </material>
-      </asset>
-      <asset xsi:type="esdl:HeatStorage" state="OPTIONAL" name="HeatStorage_74c1" id="74c13eed-9ca8-4247-bd72-a68e242d8e1b" maxDischargeRate="10000000.0" maxChargeRate="10000000.0" volume="500.0">
-        <costInformation xsi:type="esdl:CostInformation" id="4e390bc0-04b9-4c38-af99-077d7836f877">
-          <investmentCosts xsi:type="esdl:SingleValue" id="40414844-ab63-452e-9558-057d61623ba9" value="690.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="CUBIC_METRE" description="COST in EUR/m3" unit="EURO" physicalQuantity="COST" id="a95abc37-2285-4d68-88ad-dba3e1e8aaf9"/>
-          </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="22528972-1920-42d8-9e0c-115f419c31d1" value="1000000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" unit="EURO" physicalQuantity="COST" description="Cost in EUR"/>
+          <installationCosts xsi:type="esdl:SingleValue" value="100000.0" id="2b2f4b93-32c7-4f20-9723-5900cc76fe20">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="b0975eef-2e13-4b7f-b89a-64a47183e8cc" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lat="52.042658996032856" lon="4.313871860504151" CRS="WGS84"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="636a1943-2289-4d57-a2dd-33aaa4f25b49" name="In" id="8c09b9ff-5070-4fbc-97fe-db7a501932dc"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a581c340-3cab-46b1-924f-c5ddc0120de6" name="Out" id="cc725203-e648-490f-a12d-91fa85ee58f2"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_9768" id="97684360-d920-45c2-a584-a092fdcf91f1" diameter="DN450" innerDiameter="0.4444" length="149.0" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_f6e5" length="239.7" id="f6e5a760-01d5-4341-bf15-b8d33b7bea50" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311726093292237" lat="52.04487621664103"/>
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="886e5430-bec1-44e3-bab6-221c4518c810" id="bbfed830-071d-4d02-bddd-e709247c8337" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="f966bade-1fad-453f-8ec2-4062ec70bc7b" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="22fb2e85-7a81-4371-b6ab-6d5101b8ca45">
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_f6e5_ret" length="233.9" id="0db91515-418a-4bcb-9d99-9047c1ca8bdf" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311074402665649" lat="52.04281086202885"/>
+          <point xsi:type="esdl:Point" lon="4.311726093292237" lat="52.04487621664103"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" id="42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="df6f89d0-7872-4891-934f-de407f6aa142" connectedTo="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="7cbc9c32-3d7d-44e1-ab73-598459294f0c">
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:HeatStorage" name="HeatStorage_74c1" id="74c13eed-9ca8-4247-bd72-a68e242d8e1b" maxDischargeRate="10000000.0" state="OPTIONAL" maxChargeRate="10000000.0" volume="500.0">
+        <geometry xsi:type="esdl:Point" lon="4.313871860504151" CRS="WGS84" lat="52.042658996032856"/>
+        <port xsi:type="esdl:InPort" connectedTo="636a1943-2289-4d57-a2dd-33aaa4f25b49" id="8c09b9ff-5070-4fbc-97fe-db7a501932dc" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="cc725203-e648-490f-a12d-91fa85ee58f2" connectedTo="a581c340-3cab-46b1-924f-c5ddc0120de6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
+        <costInformation xsi:type="esdl:CostInformation" id="4e390bc0-04b9-4c38-af99-077d7836f877">
+          <investmentCosts xsi:type="esdl:SingleValue" value="690.0" id="40414844-ab63-452e-9558-057d61623ba9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a95abc37-2285-4d68-88ad-dba3e1e8aaf9" description="COST in EUR/m3" perUnit="CUBIC_METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="22528972-1920-42d8-9e0c-115f419c31d1">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
+          </installationCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_9768" id="97684360-d920-45c2-a584-a092fdcf91f1" innerDiameter="0.4444" length="149.0" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+          <point xsi:type="esdl:Point" lon="4.313871860504151" lat="52.042658996032856"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="2e672d8b-ee9b-4c8b-8357-58ea984ae6be" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="636a1943-2289-4d57-a2dd-33aaa4f25b49" connectedTo="8c09b9ff-5070-4fbc-97fe-db7a501932dc" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="6939255e-b8a1-4045-9739-74690c35fda4">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.042720861938854" lon="4.311695247888566"/>
-          <point xsi:type="esdl:Point" lat="52.042658996032856" lon="4.313871860504151"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="2e672d8b-ee9b-4c8b-8357-58ea984ae6be"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="8c09b9ff-5070-4fbc-97fe-db7a501932dc" name="Out" id="636a1943-2289-4d57-a2dd-33aaa4f25b49"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
-          </component>
-        </material>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_9768_ret" id="3542e501-01ea-468b-9d4f-c1e7c67b43d9" diameter="DN450" innerDiameter="0.4444" length="192.1" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="68394efa-f98e-4fbe-9418-b5975d7c0fe7">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_9768_ret" id="3542e501-01ea-468b-9d4f-c1e7c67b43d9" innerDiameter="0.4444" length="192.1" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.042658996032856" lon="4.313871860504151"/>
-          <point xsi:type="esdl:Point" lat="52.04281086202885" lon="4.311074402665649"/>
+          <point xsi:type="esdl:Point" lon="4.313871860504151" lat="52.042658996032856"/>
+          <point xsi:type="esdl:Point" lon="4.311074402665649" lat="52.04281086202885"/>
         </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="cc725203-e648-490f-a12d-91fa85ee58f2" name="In" id="a581c340-3cab-46b1-924f-c5ddc0120de6"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out" id="8271240c-cae3-4e81-8b36-d65302a4e6b4"/>
+        <port xsi:type="esdl:InPort" connectedTo="cc725203-e648-490f-a12d-91fa85ee58f2" id="a581c340-3cab-46b1-924f-c5ddc0120de6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="8271240c-cae3-4e81-8b36-d65302a4e6b4" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="68394efa-f98e-4fbe-9418-b5975d7c0fe7">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN400" name="Pipe_352c" outerDiameter="0.63" id="352cf2f0-173e-420e-b8d7-5c226b6d8565" innerDiameter="0.3938" length="233.1">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+          <point xsi:type="esdl:Point" lon="4.314751625061036" lat="52.04364884025295"/>
+        </geometry>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" id="ae32d30b-4e0d-4470-a4f0-4ba7bd258070" name="steel"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.1052">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" id="5d591b58-2cf8-4d94-91eb-be773e1c25ee" name="PUR"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0066">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" id="8a0279cc-afbf-46fb-a590-33960ce30613" name="HDPE"/>
+          </component>
+        </material>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="c7ad4fce-efbb-4b30-9508-f71a4356ca2d" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="e15db059-ab19-4483-9911-7a37f0c08e42" connectedTo="33a9041b-dd75-42c0-94a3-584c5e374927" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="ea319afa-4c85-49d6-80f6-313f6866cdc7">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="566d3f26-f85a-48b4-b06a-5fd62ac6fa61" value="2840.6">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5b1085e4-5642-4c1d-aa7c-bfb7793d4e64" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN400" name="Pipe_352c_ret" outerDiameter="0.63" id="eebe64ca-1b17-4bfa-9d0f-77129ee3716b" innerDiameter="0.3938" length="234.8">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.314306378364564" lat="52.043747823469246"/>
+          <point xsi:type="esdl:Point" lon="4.311178922653199" lat="52.04287676364216"/>
+        </geometry>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" id="ae32d30b-4e0d-4470-a4f0-4ba7bd258070" name="steel"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.1052">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" id="5d591b58-2cf8-4d94-91eb-be773e1c25ee" name="PUR"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0066">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" id="8a0279cc-afbf-46fb-a590-33960ce30613" name="HDPE"/>
+          </component>
+        </material>
+        <port xsi:type="esdl:InPort" connectedTo="0117d26b-8ab1-44b5-afee-51702e431e52" id="febc9c00-71c8-4b12-b005-28beaae24e7b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="2b341054-a732-404f-a361-d39c4cb4e271" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="aa0df5f9-2ce9-4153-8761-a4a0288edfbf">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="566d3f26-f85a-48b4-b06a-5fd62ac6fa61" value="2840.6">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5b1085e4-5642-4c1d-aa7c-bfb7793d4e64" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
       </asset>
     </area>
   </instance>

--- a/tests/models/test_case_small_network_with_ates/model/test_case_small_network_with_ates.esdl
+++ b/tests/models/test_case_small_network_with_ates/model/test_case_small_network_with_ates.esdl
@@ -1,443 +1,455 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" id="7ac09231-ce60-4c24-8338-9c0317695ba4_with_return_network" name="Untitled EnergySystem with return network" description="" esdlVersion="v2210" version="12">
+<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" name="Untitled EnergySystem with return network" id="7ac09231-ce60-4c24-8338-9c0317695ba4_with_return_network" description="" esdlVersion="v2210" version="14">
   <energySystemInformation xsi:type="esdl:EnergySystemInformation" id="e64737d9-d772-4723-b092-a0b397ac00b3">
     <carriers xsi:type="esdl:Carriers" id="9dff13b9-77cd-4b99-8777-6b7680a155b6">
       <carrier xsi:type="esdl:HeatCommodity" id="7b32e287-d775-480c-b317-64ffdacf12c9" name="Heat" supplyTemperature="70.0"/>
-      <carrier xsi:type="esdl:HeatCommodity" id="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Heat_ret" returnTemperature="40.0"/>
+      <carrier xsi:type="esdl:HeatCommodity" returnTemperature="40.0" id="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Heat_ret"/>
     </carriers>
   </energySystemInformation>
   <instance xsi:type="esdl:Instance" id="f852b941-99fe-487b-a20d-01beff9e7c43" name="Untitled Instance">
     <area xsi:type="esdl:Area" id="f4acc7ef-a37d-43b7-87cb-8af5b82e3fed" name="Untitled Area">
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_1" id="c2d77abc-1656-4722-8508-7c64574e04ef" power="10000000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04198588944146" lon="4.3088722229003915"/>
+        <port xsi:type="esdl:InPort" connectedTo="1dfdc172-9359-435a-8153-0a657932223a" id="2a873195-fa6b-4250-8519-046f040fedb7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="ef74ea8c-89b4-42e0-a98c-411860876c1a" connectedTo="18ce6906-595c-45e4-acf0-e07f7d7648c6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="d8a67243-4e4e-43f8-9801-fd4579c0eddf">
-          <installationCosts xsi:type="esdl:SingleValue" id="accd84bc-d3ed-4528-a1ff-f906c48991a1" value="1000000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" id="ae8b81fb-857b-4280-9e91-919dd1c7675e" physicalQuantity="COST" description="Cost in EUR"/>
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="accd84bc-d3ed-4528-a1ff-f906c48991a1">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="ae8b81fb-857b-4280-9e91-919dd1c7675e" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.3088722229003915" CRS="WGS84" lat="52.04198588944146"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="1dfdc172-9359-435a-8153-0a657932223a" name="In" id="2a873195-fa6b-4250-8519-046f040fedb7"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="18ce6906-595c-45e4-acf0-e07f7d7648c6" name="Out" id="ef74ea8c-89b4-42e0-a98c-411860876c1a"/>
       </asset>
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_2" id="9352d984-0e21-4af6-9c5f-91f984abfcfd" power="10000000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04002590369568" lon="4.310610294342042"/>
+        <port xsi:type="esdl:InPort" connectedTo="53a54448-abdb-41ab-a53e-498556062216" id="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" connectedTo="d126f79e-c43e-4d9d-a7ce-8f58be634695" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="7d95dc58-02b0-49cf-a7a7-5623fffb4079">
-          <installationCosts xsi:type="esdl:SingleValue" id="c33af629-6fc5-4d7c-9ac4-5b1e0db295a5" value="1000000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" id="89301826-acf3-4fec-b03c-7db277de004a" physicalQuantity="COST" description="Cost in EUR"/>
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="c33af629-6fc5-4d7c-9ac4-5b1e0db295a5">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="89301826-acf3-4fec-b03c-7db277de004a" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.310610294342042" CRS="WGS84" lat="52.04002590369568"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="53a54448-abdb-41ab-a53e-498556062216" name="In" id="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="d126f79e-c43e-4d9d-a7ce-8f58be634695" name="Out" id="bf6e0b6b-baac-468b-a9ba-f8397babf5d6"/>
       </asset>
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_3" id="e295a155-3fab-4ab1-925d-7bdb50094f48" power="10000000.0">
+        <geometry xsi:type="esdl:Point" lat="52.03796848613761" lon="4.312646090984345"/>
+        <port xsi:type="esdl:InPort" connectedTo="16b1337c-5970-4eb4-90d3-e52d514a13df" id="770022e6-3e71-4e51-8544-0dba86c46a5b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="9c025b19-57d1-43a8-b2e8-db3e684756f2" connectedTo="5cd0f2e0-d456-4909-a81c-4b312b1be857" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="3d07b171-f65b-413d-9090-2d1cd578a488">
-          <installationCosts xsi:type="esdl:SingleValue" id="ae1d6cd8-2990-4a77-a74c-65eb9c93b084" value="1000000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" id="7feb28ca-bfb8-4c0d-b1b5-ab1b397e394c" physicalQuantity="COST" description="Cost in EUR"/>
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="ae1d6cd8-2990-4a77-a74c-65eb9c93b084">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="7feb28ca-bfb8-4c0d-b1b5-ab1b397e394c" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.312646090984345" lat="52.03796848613761"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="16b1337c-5970-4eb4-90d3-e52d514a13df" name="In" id="770022e6-3e71-4e51-8544-0dba86c46a5b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="5cd0f2e0-d456-4909-a81c-4b312b1be857" name="Out" id="9c025b19-57d1-43a8-b2e8-db3e684756f2"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe1" id="Pipe1" diameter="DN450" related="Pipe1_ret" length="245.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe1_ret" diameter="DN450" name="Pipe1" length="245.7" innerDiameter="0.4444" id="Pipe1" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="52.04469805119214" lon="4.310052394866944"/>
+          <point xsi:type="esdl:Point" lat="52.04274148388849" lon="4.311720728874207"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="45bfc7d0-ef59-4f49-b37a-867b18e04b86" id="b462d564-a8c0-4ae0-a4af-36958f2455ea" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="66590f96-a397-4d6f-9cfb-e7d34232cad6" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="ec2d740c-2f13-4b70-a1bb-6e4a561414c2">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe2_ret" diameter="DN450" name="Pipe2" length="195.4" innerDiameter="0.4444" id="Pipe2" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.310052394866944" lat="52.04469805119214"/>
-          <point xsi:type="esdl:Point" lon="4.311720728874207" lat="52.04274148388849"/>
+          <point xsi:type="esdl:Point" lat="52.04271178827801" lon="4.311629533767701"/>
+          <point xsi:type="esdl:Point" lat="52.04202218466326" lon="4.309000968933106"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="45bfc7d0-ef59-4f49-b37a-867b18e04b86" name="In" id="b462d564-a8c0-4ae0-a4af-36958f2455ea"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="66590f96-a397-4d6f-9cfb-e7d34232cad6"/>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="5f65520d-61ee-4f68-8002-271f48f1daee" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="1dfdc172-9359-435a-8153-0a657932223a" connectedTo="2a873195-fa6b-4250-8519-046f040fedb7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe2" id="Pipe2" diameter="DN450" related="Pipe2_ret" length="195.4" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="c8140b3b-99dc-4ee0-b034-1050b4fd1946">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe3_ret" diameter="DN450" name="Pipe3" length="241.6" innerDiameter="0.4444" id="Pipe3" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.311629533767701" lat="52.04271178827801"/>
-          <point xsi:type="esdl:Point" lon="4.309000968933106" lat="52.04202218466326"/>
+          <point xsi:type="esdl:Point" lat="52.042708488764504" lon="4.311758279800416"/>
+          <point xsi:type="esdl:Point" lat="52.04078483093156" lon="4.31339979171753"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="5f65520d-61ee-4f68-8002-271f48f1daee"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="2a873195-fa6b-4250-8519-046f040fedb7" name="Out" id="1dfdc172-9359-435a-8153-0a657932223a"/>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="578ec414-3f11-430e-a893-60ea77848ff5" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" connectedTo="e0adf80a-b6f3-4c12-a439-dab4e555202a" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe3" id="Pipe3" diameter="DN450" related="Pipe3_ret" length="241.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="883afc13-098e-47b4-aa30-ae3c3e25f9b1">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe4_ret" diameter="DN450" name="Pipe4" length="189.7" innerDiameter="0.4444" id="Pipe4" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.311758279800416" lat="52.042708488764504"/>
-          <point xsi:type="esdl:Point" lon="4.31339979171753" lat="52.04078483093156"/>
+          <point xsi:type="esdl:Point" lat="52.04076173333622" lon="4.313324689865113"/>
+          <point xsi:type="esdl:Point" lat="52.04007209963487" lon="4.310787320137025"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="578ec414-3f11-430e-a893-60ea77848ff5"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="e0adf80a-b6f3-4c12-a439-dab4e555202a" name="Out" id="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2"/>
+        <port xsi:type="esdl:InPort" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" id="4b92e418-4ca6-4765-85ab-ce30f4127bf0" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="53a54448-abdb-41ab-a53e-498556062216" connectedTo="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe4" id="Pipe4" diameter="DN450" related="Pipe4_ret" length="189.7" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="b1dd0427-f8ca-4525-8192-8a8954f2be1c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe5_ret" diameter="DN450" name="Pipe5" length="244.6" innerDiameter="0.4444" id="Pipe5" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.313324689865113" lat="52.04076173333622"/>
-          <point xsi:type="esdl:Point" lon="4.310787320137025" lat="52.04007209963487"/>
+          <point xsi:type="esdl:Point" lat="52.04073863572898" lon="4.313453435897828"/>
+          <point xsi:type="esdl:Point" lat="52.03879839410938" lon="4.315137863159181"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" name="In" id="4b92e418-4ca6-4765-85ab-ce30f4127bf0"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" name="Out" id="53a54448-abdb-41ab-a53e-498556062216"/>
+        <port xsi:type="esdl:InPort" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" id="d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="8f1bea52-e322-4d34-ad43-7d1e97243d62" connectedTo="1cb923b5-2a69-46d9-874c-68d552ef5576" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe5" id="Pipe5" diameter="DN450" related="Pipe5_ret" length="244.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="d9132301-1f49-4c31-b38f-4e650c18a984">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.313453435897828" lat="52.04073863572898"/>
-          <point xsi:type="esdl:Point" lon="4.315137863159181" lat="52.03879839410938"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" name="In" id="d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="1cb923b5-2a69-46d9-874c-68d552ef5576" name="Out" id="8f1bea52-e322-4d34-ad43-7d1e97243d62"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
-          </component>
-        </material>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe6" id="Pipe6" diameter="DN450" related="Pipe6_ret" length="176.6" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="762aeec6-ac5d-4e54-b32f-3da929bd6713">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
+      <asset xsi:type="esdl:Pipe" related="Pipe6_ret" diameter="DN450" name="Pipe6" length="176.6" innerDiameter="0.4444" id="Pipe6" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.315094947814942" lat="52.03875219685389"/>
-          <point xsi:type="esdl:Point" lon="4.312809705734254" lat="52.03801303427292"/>
+          <point xsi:type="esdl:Point" lat="52.03875219685389" lon="4.315094947814942"/>
+          <point xsi:type="esdl:Point" lat="52.03801303427292" lon="4.312809705734254"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" name="In" id="7f162a30-7e41-4d7f-b011-ffcf4c1651f8"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="770022e6-3e71-4e51-8544-0dba86c46a5b" name="Out" id="16b1337c-5970-4eb4-90d3-e52d514a13df"/>
+        <port xsi:type="esdl:InPort" connectedTo="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" id="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="16b1337c-5970-4eb4-90d3-e52d514a13df" connectedTo="770022e6-3e71-4e51-8544-0dba86c46a5b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="762aeec6-ac5d-4e54-b32f-3da929bd6713">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
       </asset>
       <asset xsi:type="esdl:HeatProducer" power="3000000.0" name="HeatProducer_1" id="324b0371-b738-4f55-a978-3306ee81638c">
+        <geometry xsi:type="esdl:Point" lat="52.04476403847825" lon="4.309977293014527"/>
+        <port xsi:type="esdl:OutPort" id="45bfc7d0-ef59-4f49-b37a-867b18e04b86" connectedTo="b462d564-a8c0-4ae0-a4af-36958f2455ea" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <port xsi:type="esdl:InPort" connectedTo="e31e12c2-8f80-4aed-9e4b-918445a32996" id="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
         <costInformation xsi:type="esdl:CostInformation" id="28e9b853-e407-49b0-be66-1572c12dc811">
-          <investmentCosts xsi:type="esdl:SingleValue" id="b6c85259-9211-417f-b9db-89fb473f2f1c" value="900000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="47fcbff2-f0f1-48d9-b7c1-7e34a90b1539" description="Cost in EUR/MW" perMultiplier="MEGA" perUnit="WATT" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="ccba43a5-c4c8-4818-a339-762b3385f562" value="300000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" id="6924031c-0548-4b33-a341-3d03c5c2b5a0" physicalQuantity="COST" description="Cost in EUR"/>
+          <installationCosts xsi:type="esdl:SingleValue" value="300000.0" id="ccba43a5-c4c8-4818-a339-762b3385f562">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="6924031c-0548-4b33-a341-3d03c5c2b5a0" description="Cost in EUR"/>
           </installationCosts>
-          <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="b90c659f-4d87-4402-b042-90a7594e7016" value="15.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="0d948406-7864-4eff-bc65-7670533bf18b" description="Cost in EUR/MWh" perMultiplier="MEGA" perUnit="WATTHOUR" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="900000.0" id="b6c85259-9211-417f-b9db-89fb473f2f1c">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="47fcbff2-f0f1-48d9-b7c1-7e34a90b1539" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
+          </investmentCosts>
+          <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" value="15.0" id="b90c659f-4d87-4402-b042-90a7594e7016">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="0d948406-7864-4eff-bc65-7670533bf18b" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </variableOperationalAndMaintenanceCosts>
           <marginalCosts xsi:type="esdl:SingleValue" value="2.0" id="8377c514-76a2-4592-8c9c-f2e429837098">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88e78358-1344-45c2-8bbc-51de066003b1" description="Cost in EUR" physicalQuantity="COST" unit="EURO"/>
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88e78358-1344-45c2-8bbc-51de066003b1" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
           </marginalCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.309977293014527" lat="52.04476403847825"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="b462d564-a8c0-4ae0-a4af-36958f2455ea" name="Out" id="45bfc7d0-ef59-4f49-b37a-867b18e04b86"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="e31e12c2-8f80-4aed-9e4b-918445a32996" name="In" id="ba9ca084-b71f-42a3-884a-f2f2b3ae4265"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_1" id="f96d02d7-19d1-4a0b-8869-2d180f39b7e6">
-        <geometry xsi:type="esdl:Point" lon="4.311695247888566" CRS="WGS84" lat="52.042720861938854"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="66590f96-a397-4d6f-9cfb-e7d34232cad6 22016bf5-c6c4-4b98-8b96-559e9209319b f966bade-1fad-453f-8ec2-4062ec70bc7b" name="In" id="51852861-aeeb-461f-b8ec-08f000abc6dd"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="5f65520d-61ee-4f68-8002-271f48f1daee 578ec414-3f11-430e-a893-60ea77848ff5" name="Out" id="c0eac4db-f5da-47f3-8202-8438d000bd32"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.042720861938854" lon="4.311695247888566"/>
+        <port xsi:type="esdl:InPort" connectedTo="66590f96-a397-4d6f-9cfb-e7d34232cad6 f966bade-1fad-453f-8ec2-4062ec70bc7b" id="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="c0eac4db-f5da-47f3-8202-8438d000bd32" connectedTo="5f65520d-61ee-4f68-8002-271f48f1daee 578ec414-3f11-430e-a893-60ea77848ff5 2cc773ee-b562-4e1f-a1d1-a2656e10907d" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_2" id="d74db9ba-b86c-486a-8911-3ff368ae63a3">
-        <geometry xsi:type="esdl:Point" lon="4.313372969627381" CRS="WGS84" lat="52.04075678384997"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" name="In" id="e0adf80a-b6f3-4c12-a439-dab4e555202a"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="4b92e418-4ca6-4765-85ab-ce30f4127bf0 d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" name="Out" id="ed75b210-6b5a-488e-8a8d-efe570c84990"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04075678384997" lon="4.313372969627381"/>
+        <port xsi:type="esdl:InPort" connectedTo="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" id="e0adf80a-b6f3-4c12-a439-dab4e555202a" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="ed75b210-6b5a-488e-8a8d-efe570c84990" connectedTo="4b92e418-4ca6-4765-85ab-ce30f4127bf0 d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_3" id="da2f12dc-0b74-4719-bc50-18d847524db3">
-        <geometry xsi:type="esdl:Point" lon="4.315127134323121" CRS="WGS84" lat="52.038770345781394"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="8f1bea52-e322-4d34-ad43-7d1e97243d62" name="In" id="1cb923b5-2a69-46d9-874c-68d552ef5576"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" name="Out" id="a02e41ab-99f8-46d3-b2d1-be44aa5b7914"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.038770345781394" lon="4.315127134323121"/>
+        <port xsi:type="esdl:InPort" connectedTo="8f1bea52-e322-4d34-ad43-7d1e97243d62" id="1cb923b5-2a69-46d9-874c-68d552ef5576" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" connectedTo="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
-      <asset xsi:type="esdl:ATES" maxChargeRate="11610000.0" name="ATES_033c" wellDistance="150.0" salinity="10000.0" aquiferPermeability="10000.0" aquiferNetToGross="1.0" aquiferThickness="45.0" maxDischargeRate="11610000.0" wellCasingSize="13.0" id="033c2598-5c1a-48b7-93b1-c746b81819ff" aquiferAnisotropy="4.0" aquiferPorosity="0.3" aquiferMidTemperature="17.0" aquiferTopDepth="300.0">
-        <geometry xsi:type="esdl:Point" lon="4.314751625061036" CRS="WGS84" lat="52.04364884025295"/>
-        <dataSource xsi:type="esdl:DataSource" name="WarmingUp factsheet: HT-ATES (high)" description="This data was generated using the 'kosten_per_asset.xslx' file in the 'Kentallen' directory of WarmingUp project 1D" attribution=""/>
+      <asset xsi:type="esdl:ATES" aquiferNetToGross="1.0" name="ATES_033c" aquiferThickness="45.0" maxDischargeRate="11610000.0" wellCasingSize="13.0" aquiferAnisotropy="4.0" aquiferPorosity="0.3" aquiferMidTemperature="17.0" aquiferTopDepth="300.0" id="033c2598-5c1a-48b7-93b1-c746b81819ff" wellDistance="150.0" maxChargeRate="11610000.0" salinity="10000.0" aquiferPermeability="10000.0">
+        <geometry xsi:type="esdl:Point" lon="4.314944744110108" lat="52.04392599270619"/>
+        <dataSource xsi:type="esdl:DataSource" description="This data was generated using the 'kosten_per_asset.xslx' file in the 'Kentallen' directory of WarmingUp project 1D" attribution="" name="WarmingUp factsheet: HT-ATES (high)"/>
+        <port xsi:type="esdl:InPort" connectedTo="01c882f7-ec15-4d34-9f43-8181972f2500" id="6b83e74d-5ff1-4ffa-8bd4-de1154b541e2" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="InPort"/>
+        <port xsi:type="esdl:OutPort" id="11e3589b-9a2d-497e-bc2f-fff3e34d6efe" connectedTo="cad16253-f001-47f0-aeb0-1e532f5213e7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="OutPort"/>
         <costInformation xsi:type="esdl:CostInformation">
-          <investmentCosts xsi:type="esdl:SingleValue" value="233359.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a3b5cdd9-364b-4262-bce5-4658c5f1bac9" description="Cost in EUR/MW" perMultiplier="MEGA" perUnit="WATT" unit="EURO"/>
-          </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="22528972-1920-42d8-9e0c-115f419c31d1" value="1000000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" unit="EURO" physicalQuantity="COST" description="Cost in EUR"/>
-          </installationCosts>
-          <variableOperationalCosts xsi:type="esdl:SingleValue" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9" value="6.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perMultiplier="MEGA" perUnit="WATTHOUR" unit="EURO" physicalQuantity="COST"/>
+          <variableOperationalCosts xsi:type="esdl:SingleValue" value="6.0" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </variableOperationalCosts>
-        </costInformation>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="42d7c2df-a85b-45bc-b2d9-b58f03dac573" name="In" id="33a9041b-dd75-42c0-94a3-584c5e374927"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="914cd2f7-b541-46ab-b093-a364f924a44d" name="Out" id="0117d26b-8ab1-44b5-afee-51702e431e52"/>
-      </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe7" id="Pipe7" diameter="DN450" related="Pipe7_ret" length="233.1" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="586386a5-95de-40a4-b331-e46f23d431af">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="233359.0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a3b5cdd9-364b-4262-bce5-4658c5f1bac9" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO"/>
           </investmentCosts>
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="22528972-1920-42d8-9e0c-115f419c31d1">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
+          </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.314751625061036" lat="52.04364884025295"/>
-          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="0117d26b-8ab1-44b5-afee-51702e431e52" name="In" id="914cd2f7-b541-46ab-b093-a364f924a44d"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="22016bf5-c6c4-4b98-8b96-559e9209319b"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
-          </component>
-        </material>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_1_ret" id="6d97700c-a3d7-4127-b64c-f08ee2e308f9">
-        <geometry xsi:type="esdl:Point" lon="4.311074402665649" CRS="WGS84" lat="52.04281086202885"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="dd50e603-c87c-4cdb-82bb-486ebee77255 c8973070-0f1d-455a-83a1-845eec60de2b 42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" name="ret_port" id="2913e645-b027-429e-bf5d-22ace96a39fa"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="0431b8a0-a8d1-4375-b348-37a475add47a 6b655eb1-2b66-455f-90a3-0dd6f2844fab" name="ret_port" id="7893125d-d82f-4fe8-aaea-5fb6afecc635"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04281086202885" lon="4.311074402665649"/>
+        <port xsi:type="esdl:OutPort" id="2913e645-b027-429e-bf5d-22ace96a39fa" connectedTo="dd50e603-c87c-4cdb-82bb-486ebee77255 42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:InPort" connectedTo="0431b8a0-a8d1-4375-b348-37a475add47a 6b655eb1-2b66-455f-90a3-0dd6f2844fab 6ccb005c-45d4-4220-9286-cc8f77b03ec6" id="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_2_ret" id="e615c77a-bb75-411b-92c2-549efbdf8ec8">
-        <geometry xsi:type="esdl:Point" lon="4.312746245529536" CRS="WGS84" lat="52.04084678393997"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9 4b3973ab-6e4b-48af-947d-52c6d30f20ea" name="ret_port" id="a1b719cb-f735-4a30-a0d2-cf6945b3afa1"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="0650d850-58a9-45b3-8313-a3156a061988" name="ret_port" id="2dd7961b-46ce-4027-84b6-cc2684a03a7b"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04084678393997" lon="4.312746245529536"/>
+        <port xsi:type="esdl:InPort" connectedTo="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9 4b3973ab-6e4b-48af-947d-52c6d30f20ea" id="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:OutPort" id="2dd7961b-46ce-4027-84b6-cc2684a03a7b" connectedTo="0650d850-58a9-45b3-8313-a3156a061988" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_3_ret" id="a90d146f-e234-459c-974e-7867afbbb3f0">
-        <geometry xsi:type="esdl:Point" lon="4.314494347576344" CRS="WGS84" lat="52.03886034587139"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2045aca9-4e50-42ec-99de-fbcffa627a86" name="ret_port" id="f36b9767-8e64-4744-8cd0-08acb2ae873b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2b7c3acb-69a7-497d-a72f-b98db189841c" name="ret_port" id="59ccdddc-893b-4152-8bc4-0168e7e74bf3"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.03886034587139" lon="4.314494347576344"/>
+        <port xsi:type="esdl:InPort" connectedTo="2045aca9-4e50-42ec-99de-fbcffa627a86" id="f36b9767-8e64-4744-8cd0-08acb2ae873b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:OutPort" id="59ccdddc-893b-4152-8bc4-0168e7e74bf3" connectedTo="2b7c3acb-69a7-497d-a72f-b98db189841c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe1_ret" id="Pipe1_ret" diameter="DN450" related="Pipe1" length="245.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe1" diameter="DN450" name="Pipe1_ret" length="245.7" innerDiameter="0.4444" id="Pipe1_ret" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04283148397849" lon="4.311099944779182"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04478805128214" lon="4.309437355033006"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" id="dd50e603-c87c-4cdb-82bb-486ebee77255" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="e31e12c2-8f80-4aed-9e4b-918445a32996" connectedTo="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="03c07293-f6d4-4aa6-a297-5312c4d1c27e">
-          <investmentCosts xsi:type="esdl:SingleValue" id="9b449144-d0bf-45b9-8822-15dba1d4126d" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="6dbe093f-f6dd-49b4-9d5e-a2cd578611be" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="9b449144-d0bf-45b9-8822-15dba1d4126d">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="6dbe093f-f6dd-49b4-9d5e-a2cd578611be" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.311099944779182" CRS="WGS84" lat="52.04283148397849"/>
-          <point xsi:type="esdl:Point" lon="4.309437355033006" CRS="WGS84" lat="52.04478805128214"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In_ret" id="dd50e603-c87c-4cdb-82bb-486ebee77255"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" name="Out_ret" id="e31e12c2-8f80-4aed-9e4b-918445a32996"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe2_ret" id="Pipe2_ret" diameter="DN450" related="Pipe2" length="195.4" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe2" diameter="DN450" name="Pipe2_ret" length="195.4" innerDiameter="0.4444" id="Pipe2_ret" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04211218475326" lon="4.308378045386691"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04280178836801" lon="4.311008661644606"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="ef74ea8c-89b4-42e0-a98c-411860876c1a" id="18ce6906-595c-45e4-acf0-e07f7d7648c6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="0431b8a0-a8d1-4375-b348-37a475add47a" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="bec83070-2c51-4825-82f3-92434bd3e59c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="1c33024c-99c8-4168-b353-9f099b59eb60" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="26fdb8bf-6413-4272-a56b-b084823ac574" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="1c33024c-99c8-4168-b353-9f099b59eb60">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="26fdb8bf-6413-4272-a56b-b084823ac574" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.308378045386691" CRS="WGS84" lat="52.04211218475326"/>
-          <point xsi:type="esdl:Point" lon="4.311008661644606" CRS="WGS84" lat="52.04280178836801"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="ef74ea8c-89b4-42e0-a98c-411860876c1a" name="In_ret" id="18ce6906-595c-45e4-acf0-e07f7d7648c6"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out_ret" id="0431b8a0-a8d1-4375-b348-37a475add47a"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe3_ret" id="Pipe3_ret" diameter="DN450" related="Pipe3" length="241.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe3" diameter="DN450" name="Pipe3_ret" length="241.6" innerDiameter="0.4444" id="Pipe3_ret" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040874831021554" lon="4.312773152370705"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.0427984888545" lon="4.3111373978948455"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="2dd7961b-46ce-4027-84b6-cc2684a03a7b" id="0650d850-58a9-45b3-8313-a3156a061988" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="6b655eb1-2b66-455f-90a3-0dd6f2844fab" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="38f2f0f7-f814-4baf-ae3a-365af1b872db">
-          <investmentCosts xsi:type="esdl:SingleValue" id="78221659-7294-4830-802c-67e38364b1f0" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="19f63b61-453d-4213-bdc6-86f65468fec9" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="78221659-7294-4830-802c-67e38364b1f0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="19f63b61-453d-4213-bdc6-86f65468fec9" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.312773152370705" CRS="WGS84" lat="52.040874831021554"/>
-          <point xsi:type="esdl:Point" lon="4.3111373978948455" CRS="WGS84" lat="52.0427984888545"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2dd7961b-46ce-4027-84b6-cc2684a03a7b" name="In_ret" id="0650d850-58a9-45b3-8313-a3156a061988"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out_ret" id="6b655eb1-2b66-455f-90a3-0dd6f2844fab"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe4_ret" id="Pipe4_ret" diameter="DN450" related="Pipe4" length="189.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe4" diameter="DN450" name="Pipe4_ret" length="189.7" innerDiameter="0.4444" id="Pipe4_ret" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04016209972487" lon="4.310158519812684"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040851733426216" lon="4.312697980725036"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" id="d126f79e-c43e-4d9d-a7ce-8f58be634695" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="2a15456e-d23e-4064-8dee-c0588d3b05dc">
-          <investmentCosts xsi:type="esdl:SingleValue" id="0297b96a-c32c-41f8-8653-0085659dba29" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="9869b0d2-dfa3-4148-86ab-ddd1cb43b7c7" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="0297b96a-c32c-41f8-8653-0085659dba29">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="9869b0d2-dfa3-4148-86ab-ddd1cb43b7c7" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.310158519812684" CRS="WGS84" lat="52.04016209972487"/>
-          <point xsi:type="esdl:Point" lon="4.312697980725036" CRS="WGS84" lat="52.040851733426216"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" name="In_ret" id="d126f79e-c43e-4d9d-a7ce-8f58be634695"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" name="Out_ret" id="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe5_ret" id="Pipe5_ret" diameter="DN450" related="Pipe5" length="244.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe5" diameter="DN450" name="Pipe5_ret" length="244.6" innerDiameter="0.4444" id="Pipe5_ret" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.038888394199375" lon="4.314505162850188"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040828635818976" lon="4.312826656948579"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="59ccdddc-893b-4152-8bc4-0168e7e74bf3" id="2b7c3acb-69a7-497d-a72f-b98db189841c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="4b3973ab-6e4b-48af-947d-52c6d30f20ea" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="387eb458-4e3e-4e0d-bf1c-0ca2d77aa4dd">
-          <investmentCosts xsi:type="esdl:SingleValue" id="b78ac8a7-9d0e-4603-821b-febf58b48bb3" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d6547801-0eb7-4ed4-9597-1e79cc093622" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="b78ac8a7-9d0e-4603-821b-febf58b48bb3">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d6547801-0eb7-4ed4-9597-1e79cc093622" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.314505162850188" CRS="WGS84" lat="52.038888394199375"/>
-          <point xsi:type="esdl:Point" lon="4.312826656948579" CRS="WGS84" lat="52.040828635818976"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="59ccdddc-893b-4152-8bc4-0168e7e74bf3" name="In_ret" id="2b7c3acb-69a7-497d-a72f-b98db189841c"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" name="Out_ret" id="4b3973ab-6e4b-48af-947d-52c6d30f20ea"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe6_ret" id="Pipe6_ret" diameter="DN450" related="Pipe6" length="176.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe6" diameter="DN450" name="Pipe6_ret" length="176.6" innerDiameter="0.4444" id="Pipe6_ret" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.03810303436292" lon="4.312174575996732"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.03884219694389" lon="4.314462105124955"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="9c025b19-57d1-43a8-b2e8-db3e684756f2" id="5cd0f2e0-d456-4909-a81c-4b312b1be857" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="2045aca9-4e50-42ec-99de-fbcffa627a86" connectedTo="f36b9767-8e64-4744-8cd0-08acb2ae873b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="cbbb74ba-ba6f-4f17-a78f-3b3c07ce531d">
-          <investmentCosts xsi:type="esdl:SingleValue" id="ae5f4f5f-1323-4a3b-98c8-faca321a00c7" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="18570b20-b820-43d0-952a-b6eaf166c639" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="ae5f4f5f-1323-4a3b-98c8-faca321a00c7">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="18570b20-b820-43d0-952a-b6eaf166c639" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.312174575996732" CRS="WGS84" lat="52.03810303436292"/>
-          <point xsi:type="esdl:Point" lon="4.314462105124955" CRS="WGS84" lat="52.03884219694389"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="9c025b19-57d1-43a8-b2e8-db3e684756f2" name="In_ret" id="5cd0f2e0-d456-4909-a81c-4b312b1be857"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="f36b9767-8e64-4744-8cd0-08acb2ae873b" name="Out_ret" id="2045aca9-4e50-42ec-99de-fbcffa627a86"/>
-      </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe7_ret" id="Pipe7_ret" diameter="DN450" related="Pipe7" length="233.1" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="1eb6da23-b456-44fb-88a7-94ff025cee8f">
-          <investmentCosts xsi:type="esdl:SingleValue" id="9e6f7b4c-5be0-43f8-a75a-aa24c5ae0d00" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5709dcf7-d67d-437a-8d9d-6421a21b0bc0" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.311074402665649" CRS="WGS84" lat="52.04281086202885"/>
-          <point xsi:type="esdl:Point" lon="4.314133518440636" CRS="WGS84" lat="52.04373884034295"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In_ret" id="c8973070-0f1d-455a-83a1-845eec60de2b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="33a9041b-dd75-42c0-94a3-584c5e374927" name="Out_ret" id="42d7c2df-a85b-45bc-b2d9-b58f03dac573"/>
       </asset>
       <asset xsi:type="esdl:HeatProducer" power="2500000.0" name="HeatProducer_2" id="da00ddfc-cfa4-4f21-b5be-7c69d2bf53bb">
+        <geometry xsi:type="esdl:Point" lon="4.311726093292237" CRS="WGS84" lat="52.04487621664103"/>
+        <port xsi:type="esdl:OutPort" id="886e5430-bec1-44e3-bab6-221c4518c810" connectedTo="bbfed830-071d-4d02-bddd-e709247c8337" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <port xsi:type="esdl:InPort" connectedTo="df6f89d0-7872-4891-934f-de407f6aa142" id="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
         <costInformation xsi:type="esdl:CostInformation" id="d59fe0c4-5156-4dcf-b259-6ac6855241c6">
-          <investmentCosts xsi:type="esdl:SingleValue" id="3633cd09-9f87-4d8d-a5f8-0431bab9576d" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88a009ff-0eeb-48b1-9eb3-60dba04b3e79" description="Cost in EUR/MW" perMultiplier="MEGA" perUnit="WATT" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="2b2f4b93-32c7-4f20-9723-5900cc76fe20" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="b0975eef-2e13-4b7f-b89a-64a47183e8cc" unit="EURO" physicalQuantity="COST" description="Cost in EUR"/>
-          </installationCosts>
-          <variableOperationalCosts xsi:type="esdl:SingleValue" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9" value="6.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perMultiplier="MEGA" perUnit="WATTHOUR" unit="EURO" physicalQuantity="COST"/>
+          <variableOperationalCosts xsi:type="esdl:SingleValue" value="6.0" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </variableOperationalCosts>
+          <installationCosts xsi:type="esdl:SingleValue" value="100000.0" id="2b2f4b93-32c7-4f20-9723-5900cc76fe20">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="b0975eef-2e13-4b7f-b89a-64a47183e8cc" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
+          </installationCosts>
+          <investmentCosts xsi:type="esdl:SingleValue" value="100000.0" id="3633cd09-9f87-4d8d-a5f8-0431bab9576d">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88a009ff-0eeb-48b1-9eb3-60dba04b3e79" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
+          </investmentCosts>
           <marginalCosts xsi:type="esdl:SingleValue" value="1.0" id="3f73bd26-b923-4e2a-8f8e-435c8a783d8d">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a1086a77-a2d1-4a9b-a6f2-adf0e4380eca" description="Cost in EUR" physicalQuantity="COST" unit="EURO"/>
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a1086a77-a2d1-4a9b-a6f2-adf0e4380eca" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
           </marginalCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237" CRS="WGS84"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="bbfed830-071d-4d02-bddd-e709247c8337" name="Out" id="886e5430-bec1-44e3-bab6-221c4518c810"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="df6f89d0-7872-4891-934f-de407f6aa142" name="In" id="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe_f6e5" id="f6e5a760-01d5-4341-bf15-b8d33b7bea50" diameter="DN450" length="239.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_f6e5" length="239.7" innerDiameter="0.4444" id="f6e5a760-01d5-4341-bf15-b8d33b7bea50" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311726093292237" lat="52.04487621664103"/>
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="886e5430-bec1-44e3-bab6-221c4518c810" id="bbfed830-071d-4d02-bddd-e709247c8337" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="f966bade-1fad-453f-8ec2-4062ec70bc7b" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="22fb2e85-7a81-4371-b6ab-6d5101b8ca45">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237"/>
-          <point xsi:type="esdl:Point" lat="52.042720861938854" lon="4.311695247888566"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="886e5430-bec1-44e3-bab6-221c4518c810" name="In" id="bbfed830-071d-4d02-bddd-e709247c8337"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="f966bade-1fad-453f-8ec2-4062ec70bc7b"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
-          </component>
-        </material>
       </asset>
-      <asset xsi:type="esdl:Pipe" name="Pipe_f6e5_ret" id="0db91515-418a-4bcb-9d99-9047c1ca8bdf" diameter="DN450" length="233.9" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="7cbc9c32-3d7d-44e1-ab73-598459294f0c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_f6e5_ret" length="233.9" innerDiameter="0.4444" id="0db91515-418a-4bcb-9d99-9047c1ca8bdf" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.04281086202885" lon="4.311074402665649"/>
-          <point xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237"/>
+          <point xsi:type="esdl:Point" lon="4.311074402665649" lat="52.04281086202885"/>
+          <point xsi:type="esdl:Point" lon="4.311726093292237" lat="52.04487621664103"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In" id="42e9f86b-ea96-4992-bf3f-9cbae8a4a39c"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" name="Out" id="df6f89d0-7872-4891-934f-de407f6aa142"/>
+        <port xsi:type="esdl:InPort" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" id="42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="df6f89d0-7872-4891-934f-de407f6aa142" connectedTo="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="7cbc9c32-3d7d-44e1-ab73-598459294f0c">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN400" name="Pipe_b2a4" outerDiameter="0.63" id="b2a4149b-ab5c-46fb-807e-ab567d859c2a" innerDiameter="0.3938" length="259.5">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+          <point xsi:type="esdl:Point" lon="4.314944744110108" lat="52.04392599270619"/>
+        </geometry>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" id="ae32d30b-4e0d-4470-a4f0-4ba7bd258070" name="steel"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.1052">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" id="5d591b58-2cf8-4d94-91eb-be773e1c25ee" name="PUR"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0066">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" id="8a0279cc-afbf-46fb-a590-33960ce30613" name="HDPE"/>
+          </component>
+        </material>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="2cc773ee-b562-4e1f-a1d1-a2656e10907d" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="01c882f7-ec15-4d34-9f43-8181972f2500" connectedTo="6b83e74d-5ff1-4ffa-8bd4-de1154b541e2" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="facb610a-1bbc-4503-8e02-9a767558ecdf">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="566d3f26-f85a-48b4-b06a-5fd62ac6fa61" value="2840.6">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5b1085e4-5642-4c1d-aa7c-bfb7793d4e64" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN400" name="Pipe_b2a4_ret" outerDiameter="0.63" id="a5276030-a347-45b5-9b8b-1cda3ada4590" innerDiameter="0.3938" length="259.1">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.314504861831666" lat="52.044031574141066"/>
+          <point xsi:type="esdl:Point" lon="4.311189651489259" lat="52.04290315964392"/>
+        </geometry>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" id="ae32d30b-4e0d-4470-a4f0-4ba7bd258070" name="steel"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.1052">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" id="5d591b58-2cf8-4d94-91eb-be773e1c25ee" name="PUR"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0066">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" id="8a0279cc-afbf-46fb-a590-33960ce30613" name="HDPE"/>
+          </component>
+        </material>
+        <port xsi:type="esdl:InPort" connectedTo="11e3589b-9a2d-497e-bc2f-fff3e34d6efe" id="cad16253-f001-47f0-aeb0-1e532f5213e7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="6ccb005c-45d4-4220-9286-cc8f77b03ec6" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="0dd571cb-b7da-4de4-bdec-6ad5a4233558">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="566d3f26-f85a-48b4-b06a-5fd62ac6fa61" value="2840.6">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5b1085e4-5642-4c1d-aa7c-bfb7793d4e64" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
       </asset>
     </area>
   </instance>

--- a/tests/models/test_case_small_network_with_ates/src/run_ates.py
+++ b/tests/models/test_case_small_network_with_ates/src/run_ates.py
@@ -350,13 +350,14 @@ if __name__ == "__main__":
     sol = run_optimization_problem(HeatProblem)
     results = sol.extract_results()
     import matplotlib.pyplot as plt
+
     plt.figure()
     plt.plot(results["ATES_033c.Heat_ates"])
     plt.figure()
     plt.plot(results["ATES_033c.Stored_heat"])
     plt.show()
-    a=2
-    a=1
+    a = 2
+    a = 1
 
     # solution = run_optimization_problem(
     #     HeatProblemSetPoints, **{"timed_setpoints": {"HeatProducer_1": (24 * 365, 2)}}

--- a/tests/models/test_case_small_network_with_ates/src/run_ates.py
+++ b/tests/models/test_case_small_network_with_ates/src/run_ates.py
@@ -84,6 +84,11 @@ class HeatProblem(
         options["minimum_velocity"] = 0.0
         return options
 
+    def solver_options(self):
+        options = super().solver_options()
+        options["solver"] = "highs"
+        return options
+
     def constraints(self, ensemble_member):
         constraints = super().constraints(ensemble_member)
 
@@ -342,6 +347,17 @@ class HeatProblemSetPoints(
 
 
 if __name__ == "__main__":
-    solution = run_optimization_problem(
-        HeatProblemSetPoints, **{"timed_setpoints": {"HeatProducer_1": (24 * 365, 2)}}
-    )
+    sol = run_optimization_problem(HeatProblem)
+    results = sol.extract_results()
+    import matplotlib.pyplot as plt
+    plt.figure()
+    plt.plot(results["ATES_033c.Heat_ates"])
+    plt.figure()
+    plt.plot(results["ATES_033c.Stored_heat"])
+    plt.show()
+    a=2
+    a=1
+
+    # solution = run_optimization_problem(
+    #     HeatProblemSetPoints, **{"timed_setpoints": {"HeatProducer_1": (24 * 365, 2)}}
+    # )

--- a/tests/models/test_case_small_network_with_ates/src/run_ates.py
+++ b/tests/models/test_case_small_network_with_ates/src/run_ates.py
@@ -94,7 +94,9 @@ class HeatProblem(
 
         for a in self.heat_network_components.get("ates", []):
             stored_heat = self.state_vector(f"{a}.Stored_heat")
+            heat_ates = self.state_vector(f"{a}.Heat_ates")
             constraints.append((stored_heat[0] - stored_heat[-1], 0.0, 0.0))
+            constraints.append((heat_ates[0], 0.0, 0.0))
 
         return constraints
 

--- a/tests/models/test_case_small_network_with_ates_with_buffer/model/test_case_small_network_with_ates_with_buffer.esdl
+++ b/tests/models/test_case_small_network_with_ates_with_buffer/model/test_case_small_network_with_ates_with_buffer.esdl
@@ -1,497 +1,509 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" id="7ac09231-ce60-4c24-8338-9c0317695ba4_with_return_network" name="Untitled EnergySystem with return network" description="" esdlVersion="v2210" version="13">
+<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" name="Untitled EnergySystem with return network" id="7ac09231-ce60-4c24-8338-9c0317695ba4_with_return_network" description="" esdlVersion="v2210" version="14">
   <energySystemInformation xsi:type="esdl:EnergySystemInformation" id="e64737d9-d772-4723-b092-a0b397ac00b3">
     <carriers xsi:type="esdl:Carriers" id="9dff13b9-77cd-4b99-8777-6b7680a155b6">
       <carrier xsi:type="esdl:HeatCommodity" id="7b32e287-d775-480c-b317-64ffdacf12c9" name="Heat" supplyTemperature="70.0"/>
-      <carrier xsi:type="esdl:HeatCommodity" id="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Heat_ret" returnTemperature="40.0"/>
+      <carrier xsi:type="esdl:HeatCommodity" returnTemperature="40.0" id="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Heat_ret"/>
     </carriers>
   </energySystemInformation>
   <instance xsi:type="esdl:Instance" id="f852b941-99fe-487b-a20d-01beff9e7c43" name="Untitled Instance">
     <area xsi:type="esdl:Area" id="f4acc7ef-a37d-43b7-87cb-8af5b82e3fed" name="Untitled Area">
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_1" id="c2d77abc-1656-4722-8508-7c64574e04ef" power="10000000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04198588944146" lon="4.3088722229003915"/>
+        <port xsi:type="esdl:InPort" connectedTo="1dfdc172-9359-435a-8153-0a657932223a" id="2a873195-fa6b-4250-8519-046f040fedb7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="ef74ea8c-89b4-42e0-a98c-411860876c1a" connectedTo="18ce6906-595c-45e4-acf0-e07f7d7648c6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="d8a67243-4e4e-43f8-9801-fd4579c0eddf">
-          <installationCosts xsi:type="esdl:SingleValue" id="accd84bc-d3ed-4528-a1ff-f906c48991a1" value="1000000.0">
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="accd84bc-d3ed-4528-a1ff-f906c48991a1">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="ae8b81fb-857b-4280-9e91-919dd1c7675e" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.3088722229003915" CRS="WGS84" lat="52.04198588944146"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="1dfdc172-9359-435a-8153-0a657932223a" name="In" id="2a873195-fa6b-4250-8519-046f040fedb7"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="18ce6906-595c-45e4-acf0-e07f7d7648c6" name="Out" id="ef74ea8c-89b4-42e0-a98c-411860876c1a"/>
       </asset>
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_2" id="9352d984-0e21-4af6-9c5f-91f984abfcfd" power="10000000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04002590369568" lon="4.310610294342042"/>
+        <port xsi:type="esdl:InPort" connectedTo="53a54448-abdb-41ab-a53e-498556062216" id="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" connectedTo="d126f79e-c43e-4d9d-a7ce-8f58be634695" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="7d95dc58-02b0-49cf-a7a7-5623fffb4079">
-          <installationCosts xsi:type="esdl:SingleValue" id="c33af629-6fc5-4d7c-9ac4-5b1e0db295a5" value="1000000.0">
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="c33af629-6fc5-4d7c-9ac4-5b1e0db295a5">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="89301826-acf3-4fec-b03c-7db277de004a" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.310610294342042" CRS="WGS84" lat="52.04002590369568"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="53a54448-abdb-41ab-a53e-498556062216" name="In" id="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="d126f79e-c43e-4d9d-a7ce-8f58be634695" name="Out" id="bf6e0b6b-baac-468b-a9ba-f8397babf5d6"/>
       </asset>
       <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_3" id="e295a155-3fab-4ab1-925d-7bdb50094f48" power="10000000.0">
+        <geometry xsi:type="esdl:Point" lat="52.03796848613761" lon="4.312646090984345"/>
+        <port xsi:type="esdl:InPort" connectedTo="16b1337c-5970-4eb4-90d3-e52d514a13df" id="770022e6-3e71-4e51-8544-0dba86c46a5b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="9c025b19-57d1-43a8-b2e8-db3e684756f2" connectedTo="5cd0f2e0-d456-4909-a81c-4b312b1be857" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="3d07b171-f65b-413d-9090-2d1cd578a488">
-          <installationCosts xsi:type="esdl:SingleValue" id="ae1d6cd8-2990-4a77-a74c-65eb9c93b084" value="1000000.0">
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="ae1d6cd8-2990-4a77-a74c-65eb9c93b084">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="7feb28ca-bfb8-4c0d-b1b5-ab1b397e394c" description="Cost in EUR"/>
           </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.312646090984345" lat="52.03796848613761"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="16b1337c-5970-4eb4-90d3-e52d514a13df" name="In" id="770022e6-3e71-4e51-8544-0dba86c46a5b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="5cd0f2e0-d456-4909-a81c-4b312b1be857" name="Out" id="9c025b19-57d1-43a8-b2e8-db3e684756f2"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe1" id="Pipe1" diameter="DN450" related="Pipe1_ret" length="245.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe1_ret" diameter="DN450" name="Pipe1" length="245.7" id="Pipe1" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="52.04469805119214" lon="4.310052394866944"/>
+          <point xsi:type="esdl:Point" lat="52.04274148388849" lon="4.311720728874207"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="45bfc7d0-ef59-4f49-b37a-867b18e04b86" id="b462d564-a8c0-4ae0-a4af-36958f2455ea" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="66590f96-a397-4d6f-9cfb-e7d34232cad6" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="ec2d740c-2f13-4b70-a1bb-6e4a561414c2">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe2_ret" diameter="DN450" name="Pipe2" length="195.4" id="Pipe2" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.310052394866944" lat="52.04469805119214"/>
-          <point xsi:type="esdl:Point" lon="4.311720728874207" lat="52.04274148388849"/>
+          <point xsi:type="esdl:Point" lat="52.04271178827801" lon="4.311629533767701"/>
+          <point xsi:type="esdl:Point" lat="52.04202218466326" lon="4.309000968933106"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="45bfc7d0-ef59-4f49-b37a-867b18e04b86" name="In" id="b462d564-a8c0-4ae0-a4af-36958f2455ea"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="66590f96-a397-4d6f-9cfb-e7d34232cad6"/>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="5f65520d-61ee-4f68-8002-271f48f1daee" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="1dfdc172-9359-435a-8153-0a657932223a" connectedTo="2a873195-fa6b-4250-8519-046f040fedb7" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe2" id="Pipe2" diameter="DN450" related="Pipe2_ret" length="195.4" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="c8140b3b-99dc-4ee0-b034-1050b4fd1946">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe3_ret" diameter="DN450" name="Pipe3" length="241.6" id="Pipe3" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.311629533767701" lat="52.04271178827801"/>
-          <point xsi:type="esdl:Point" lon="4.309000968933106" lat="52.04202218466326"/>
+          <point xsi:type="esdl:Point" lat="52.042708488764504" lon="4.311758279800416"/>
+          <point xsi:type="esdl:Point" lat="52.04078483093156" lon="4.31339979171753"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="5f65520d-61ee-4f68-8002-271f48f1daee"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="2a873195-fa6b-4250-8519-046f040fedb7" name="Out" id="1dfdc172-9359-435a-8153-0a657932223a"/>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="578ec414-3f11-430e-a893-60ea77848ff5" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" connectedTo="e0adf80a-b6f3-4c12-a439-dab4e555202a" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe3" id="Pipe3" diameter="DN450" related="Pipe3_ret" length="241.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="883afc13-098e-47b4-aa30-ae3c3e25f9b1">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe4_ret" diameter="DN450" name="Pipe4" length="189.7" id="Pipe4" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.311758279800416" lat="52.042708488764504"/>
-          <point xsi:type="esdl:Point" lon="4.31339979171753" lat="52.04078483093156"/>
+          <point xsi:type="esdl:Point" lat="52.04076173333622" lon="4.313324689865113"/>
+          <point xsi:type="esdl:Point" lat="52.04007209963487" lon="4.310787320137025"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="578ec414-3f11-430e-a893-60ea77848ff5"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="e0adf80a-b6f3-4c12-a439-dab4e555202a" name="Out" id="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2"/>
+        <port xsi:type="esdl:InPort" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" id="4b92e418-4ca6-4765-85ab-ce30f4127bf0" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="53a54448-abdb-41ab-a53e-498556062216" connectedTo="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe4" id="Pipe4" diameter="DN450" related="Pipe4_ret" length="189.7" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="b1dd0427-f8ca-4525-8192-8a8954f2be1c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe5_ret" diameter="DN450" name="Pipe5" length="244.6" id="Pipe5" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.313324689865113" lat="52.04076173333622"/>
-          <point xsi:type="esdl:Point" lon="4.310787320137025" lat="52.04007209963487"/>
+          <point xsi:type="esdl:Point" lat="52.04073863572898" lon="4.313453435897828"/>
+          <point xsi:type="esdl:Point" lat="52.03879839410938" lon="4.315137863159181"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" name="In" id="4b92e418-4ca6-4765-85ab-ce30f4127bf0"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="a4a7c23e-4d77-4bbe-b8b4-ddf2d2d6e97e" name="Out" id="53a54448-abdb-41ab-a53e-498556062216"/>
+        <port xsi:type="esdl:InPort" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" id="d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="8f1bea52-e322-4d34-ad43-7d1e97243d62" connectedTo="1cb923b5-2a69-46d9-874c-68d552ef5576" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe5" id="Pipe5" diameter="DN450" related="Pipe5_ret" length="244.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="d9132301-1f49-4c31-b38f-4e650c18a984">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" related="Pipe6_ret" diameter="DN450" name="Pipe6" length="176.6" id="Pipe6" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.313453435897828" lat="52.04073863572898"/>
-          <point xsi:type="esdl:Point" lon="4.315137863159181" lat="52.03879839410938"/>
+          <point xsi:type="esdl:Point" lat="52.03875219685389" lon="4.315094947814942"/>
+          <point xsi:type="esdl:Point" lat="52.03801303427292" lon="4.312809705734254"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="ed75b210-6b5a-488e-8a8d-efe570c84990" name="In" id="d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="1cb923b5-2a69-46d9-874c-68d552ef5576" name="Out" id="8f1bea52-e322-4d34-ad43-7d1e97243d62"/>
+        <port xsi:type="esdl:InPort" connectedTo="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" id="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="16b1337c-5970-4eb4-90d3-e52d514a13df" connectedTo="770022e6-3e71-4e51-8544-0dba86c46a5b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe6" id="Pipe6" diameter="DN450" related="Pipe6_ret" length="176.6" innerDiameter="0.4444" outerDiameter="0.63">
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="762aeec6-ac5d-4e54-b32f-3da929bd6713">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.315094947814942" lat="52.03875219685389"/>
-          <point xsi:type="esdl:Point" lon="4.312809705734254" lat="52.03801303427292"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" name="In" id="7f162a30-7e41-4d7f-b011-ffcf4c1651f8"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="770022e6-3e71-4e51-8544-0dba86c46a5b" name="Out" id="16b1337c-5970-4eb4-90d3-e52d514a13df"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
-          </component>
-        </material>
       </asset>
-      <asset xsi:type="esdl:HeatProducer" state="OPTIONAL" power="3000000.0" name="HeatProducer_1" id="324b0371-b738-4f55-a978-3306ee81638c">
+      <asset xsi:type="esdl:HeatProducer" power="3000000.0" name="HeatProducer_1" id="324b0371-b738-4f55-a978-3306ee81638c" state="OPTIONAL">
+        <geometry xsi:type="esdl:Point" lat="52.04476403847825" lon="4.309977293014527"/>
+        <port xsi:type="esdl:OutPort" id="45bfc7d0-ef59-4f49-b37a-867b18e04b86" connectedTo="b462d564-a8c0-4ae0-a4af-36958f2455ea" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <port xsi:type="esdl:InPort" connectedTo="e31e12c2-8f80-4aed-9e4b-918445a32996" id="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
         <costInformation xsi:type="esdl:CostInformation" id="28e9b853-e407-49b0-be66-1572c12dc811">
-          <investmentCosts xsi:type="esdl:SingleValue" id="b6c85259-9211-417f-b9db-89fb473f2f1c" value="100000.0">
+          <investmentCosts xsi:type="esdl:SingleValue" value="100000.0" id="b6c85259-9211-417f-b9db-89fb473f2f1c">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="47fcbff2-f0f1-48d9-b7c1-7e34a90b1539" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="ccba43a5-c4c8-4818-a339-762b3385f562" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="6924031c-0548-4b33-a341-3d03c5c2b5a0" description="Cost in EUR"/>
-          </installationCosts>
-          <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" id="b90c659f-4d87-4402-b042-90a7594e7016" value="15.0">
+          <variableOperationalAndMaintenanceCosts xsi:type="esdl:SingleValue" value="15.0" id="b90c659f-4d87-4402-b042-90a7594e7016">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="0d948406-7864-4eff-bc65-7670533bf18b" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </variableOperationalAndMaintenanceCosts>
+          <installationCosts xsi:type="esdl:SingleValue" value="100000.0" id="ccba43a5-c4c8-4818-a339-762b3385f562">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" unit="EURO" physicalQuantity="COST" id="6924031c-0548-4b33-a341-3d03c5c2b5a0" description="Cost in EUR"/>
+          </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lon="4.309977293014527" lat="52.04476403847825"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="b462d564-a8c0-4ae0-a4af-36958f2455ea" name="Out" id="45bfc7d0-ef59-4f49-b37a-867b18e04b86"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="e31e12c2-8f80-4aed-9e4b-918445a32996" name="In" id="ba9ca084-b71f-42a3-884a-f2f2b3ae4265"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_1" id="f96d02d7-19d1-4a0b-8869-2d180f39b7e6">
-        <geometry xsi:type="esdl:Point" lon="4.311695247888566" CRS="WGS84" lat="52.042720861938854"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="66590f96-a397-4d6f-9cfb-e7d34232cad6 22016bf5-c6c4-4b98-8b96-559e9209319b f966bade-1fad-453f-8ec2-4062ec70bc7b" name="In" id="51852861-aeeb-461f-b8ec-08f000abc6dd"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="5f65520d-61ee-4f68-8002-271f48f1daee 578ec414-3f11-430e-a893-60ea77848ff5 2e672d8b-ee9b-4c8b-8357-58ea984ae6be" name="Out" id="c0eac4db-f5da-47f3-8202-8438d000bd32"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.042720861938854" lon="4.311695247888566"/>
+        <port xsi:type="esdl:InPort" connectedTo="66590f96-a397-4d6f-9cfb-e7d34232cad6 f966bade-1fad-453f-8ec2-4062ec70bc7b" id="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="c0eac4db-f5da-47f3-8202-8438d000bd32" connectedTo="5f65520d-61ee-4f68-8002-271f48f1daee 578ec414-3f11-430e-a893-60ea77848ff5 2e672d8b-ee9b-4c8b-8357-58ea984ae6be d89aec21-40a8-4014-86ee-2aba9f3ccbe5" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_2" id="d74db9ba-b86c-486a-8911-3ff368ae63a3">
-        <geometry xsi:type="esdl:Point" lon="4.313372969627381" CRS="WGS84" lat="52.04075678384997"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" name="In" id="e0adf80a-b6f3-4c12-a439-dab4e555202a"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="4b92e418-4ca6-4765-85ab-ce30f4127bf0 d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" name="Out" id="ed75b210-6b5a-488e-8a8d-efe570c84990"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04075678384997" lon="4.313372969627381"/>
+        <port xsi:type="esdl:InPort" connectedTo="dc1bc94f-26f2-4a49-a3bf-d0614b1f0df2" id="e0adf80a-b6f3-4c12-a439-dab4e555202a" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="ed75b210-6b5a-488e-8a8d-efe570c84990" connectedTo="4b92e418-4ca6-4765-85ab-ce30f4127bf0 d1ce17fe-572d-4ade-a6e1-a3d3aa0fab64" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_3" id="da2f12dc-0b74-4719-bc50-18d847524db3">
-        <geometry xsi:type="esdl:Point" lon="4.315127134323121" CRS="WGS84" lat="52.038770345781394"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="8f1bea52-e322-4d34-ad43-7d1e97243d62" name="In" id="1cb923b5-2a69-46d9-874c-68d552ef5576"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" name="Out" id="a02e41ab-99f8-46d3-b2d1-be44aa5b7914"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.038770345781394" lon="4.315127134323121"/>
+        <port xsi:type="esdl:InPort" connectedTo="8f1bea52-e322-4d34-ad43-7d1e97243d62" id="1cb923b5-2a69-46d9-874c-68d552ef5576" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="a02e41ab-99f8-46d3-b2d1-be44aa5b7914" connectedTo="7f162a30-7e41-4d7f-b011-ffcf4c1651f8" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
       </asset>
-      <asset xsi:type="esdl:ATES" maxChargeRate="11610000.0" name="ATES_033c" wellDistance="150.0" salinity="10000.0" aquiferPermeability="10000.0" aquiferNetToGross="1.0" aquiferThickness="45.0" maxDischargeRate="11610000.0" wellCasingSize="13.0" id="033c2598-5c1a-48b7-93b1-c746b81819ff" aquiferAnisotropy="4.0" aquiferPorosity="0.3" aquiferMidTemperature="17.0" aquiferTopDepth="300.0">
-        <geometry xsi:type="esdl:Point" lon="4.314751625061036" CRS="WGS84" lat="52.04364884025295"/>
-        <dataSource xsi:type="esdl:DataSource" name="WarmingUp factsheet: HT-ATES (high)" description="This data was generated using the 'kosten_per_asset.xslx' file in the 'Kentallen' directory of WarmingUp project 1D" attribution=""/>
+      <asset xsi:type="esdl:ATES" aquiferNetToGross="1.0" name="ATES_033c" aquiferThickness="45.0" maxDischargeRate="11610000.0" wellCasingSize="13.0" aquiferAnisotropy="4.0" aquiferPorosity="0.3" aquiferMidTemperature="17.0" aquiferTopDepth="300.0" id="033c2598-5c1a-48b7-93b1-c746b81819ff" wellDistance="150.0" maxChargeRate="11610000.0" salinity="10000.0" aquiferPermeability="10000.0">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04364884025295" lon="4.314751625061036"/>
+        <dataSource xsi:type="esdl:DataSource" description="This data was generated using the 'kosten_per_asset.xslx' file in the 'Kentallen' directory of WarmingUp project 1D" attribution="" name="WarmingUp factsheet: HT-ATES (high)"/>
+        <port xsi:type="esdl:InPort" connectedTo="350d66d9-dea3-4a42-85e4-ec9e2c127444" id="33a9041b-dd75-42c0-94a3-584c5e374927" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="0117d26b-8ab1-44b5-afee-51702e431e52" connectedTo="3ec3a129-928e-4152-9f98-2baa194e66c4" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation">
+          <variableOperationalCosts xsi:type="esdl:SingleValue" value="6.0" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
+          </variableOperationalCosts>
           <investmentCosts xsi:type="esdl:SingleValue" value="233359.0">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a3b5cdd9-364b-4262-bce5-4658c5f1bac9" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO"/>
           </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="22528972-1920-42d8-9e0c-115f419c31d1" value="1000000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" unit="EURO" physicalQuantity="COST" description="Cost in EUR"/>
+          <installationCosts xsi:type="esdl:SingleValue" value="1000000.0" id="22528972-1920-42d8-9e0c-115f419c31d1">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="620a8529-43ec-4674-8ed3-10befaff0742" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
           </installationCosts>
-          <variableOperationalCosts xsi:type="esdl:SingleValue" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9" value="6.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
-          </variableOperationalCosts>
         </costInformation>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="42d7c2df-a85b-45bc-b2d9-b58f03dac573" name="In" id="33a9041b-dd75-42c0-94a3-584c5e374927"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="914cd2f7-b541-46ab-b093-a364f924a44d" name="Out" id="0117d26b-8ab1-44b5-afee-51702e431e52"/>
-      </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe7" id="Pipe7" diameter="DN450" related="Pipe7_ret" length="233.1" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="586386a5-95de-40a4-b331-e46f23d431af">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lon="4.314751625061036" lat="52.04364884025295"/>
-          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="0117d26b-8ab1-44b5-afee-51702e431e52" name="In" id="914cd2f7-b541-46ab-b093-a364f924a44d"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="22016bf5-c6c4-4b98-8b96-559e9209319b"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
-          </component>
-        </material>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_1_ret" id="6d97700c-a3d7-4127-b64c-f08ee2e308f9">
-        <geometry xsi:type="esdl:Point" lon="4.311074402665649" CRS="WGS84" lat="52.04281086202885"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="dd50e603-c87c-4cdb-82bb-486ebee77255 c8973070-0f1d-455a-83a1-845eec60de2b 42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" name="ret_port" id="2913e645-b027-429e-bf5d-22ace96a39fa"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="0431b8a0-a8d1-4375-b348-37a475add47a 6b655eb1-2b66-455f-90a3-0dd6f2844fab 8271240c-cae3-4e81-8b36-d65302a4e6b4" name="ret_port" id="7893125d-d82f-4fe8-aaea-5fb6afecc635"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04281086202885" lon="4.311074402665649"/>
+        <port xsi:type="esdl:OutPort" id="2913e645-b027-429e-bf5d-22ace96a39fa" connectedTo="dd50e603-c87c-4cdb-82bb-486ebee77255 42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:InPort" connectedTo="0431b8a0-a8d1-4375-b348-37a475add47a 6b655eb1-2b66-455f-90a3-0dd6f2844fab 8271240c-cae3-4e81-8b36-d65302a4e6b4 b314b276-dcb4-4668-a337-5eef17ff164d" id="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_2_ret" id="e615c77a-bb75-411b-92c2-549efbdf8ec8">
-        <geometry xsi:type="esdl:Point" lon="4.312746245529536" CRS="WGS84" lat="52.04084678393997"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9 4b3973ab-6e4b-48af-947d-52c6d30f20ea" name="ret_port" id="a1b719cb-f735-4a30-a0d2-cf6945b3afa1"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="0650d850-58a9-45b3-8313-a3156a061988" name="ret_port" id="2dd7961b-46ce-4027-84b6-cc2684a03a7b"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.04084678393997" lon="4.312746245529536"/>
+        <port xsi:type="esdl:InPort" connectedTo="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9 4b3973ab-6e4b-48af-947d-52c6d30f20ea" id="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:OutPort" id="2dd7961b-46ce-4027-84b6-cc2684a03a7b" connectedTo="0650d850-58a9-45b3-8313-a3156a061988" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
       <asset xsi:type="esdl:Joint" name="Joint_3_ret" id="a90d146f-e234-459c-974e-7867afbbb3f0">
-        <geometry xsi:type="esdl:Point" lon="4.314494347576344" CRS="WGS84" lat="52.03886034587139"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2045aca9-4e50-42ec-99de-fbcffa627a86" name="ret_port" id="f36b9767-8e64-4744-8cd0-08acb2ae873b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2b7c3acb-69a7-497d-a72f-b98db189841c" name="ret_port" id="59ccdddc-893b-4152-8bc4-0168e7e74bf3"/>
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.03886034587139" lon="4.314494347576344"/>
+        <port xsi:type="esdl:InPort" connectedTo="2045aca9-4e50-42ec-99de-fbcffa627a86" id="f36b9767-8e64-4744-8cd0-08acb2ae873b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
+        <port xsi:type="esdl:OutPort" id="59ccdddc-893b-4152-8bc4-0168e7e74bf3" connectedTo="2b7c3acb-69a7-497d-a72f-b98db189841c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="ret_port"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe1_ret" id="Pipe1_ret" diameter="DN450" related="Pipe1" length="245.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe1" diameter="DN450" name="Pipe1_ret" length="245.7" id="Pipe1_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04283148397849" lon="4.311099944779182"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04478805128214" lon="4.309437355033006"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" id="dd50e603-c87c-4cdb-82bb-486ebee77255" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="e31e12c2-8f80-4aed-9e4b-918445a32996" connectedTo="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="03c07293-f6d4-4aa6-a297-5312c4d1c27e">
-          <investmentCosts xsi:type="esdl:SingleValue" id="9b449144-d0bf-45b9-8822-15dba1d4126d" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="6dbe093f-f6dd-49b4-9d5e-a2cd578611be" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="9b449144-d0bf-45b9-8822-15dba1d4126d">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="6dbe093f-f6dd-49b4-9d5e-a2cd578611be" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.311099944779182" CRS="WGS84" lat="52.04283148397849"/>
-          <point xsi:type="esdl:Point" lon="4.309437355033006" CRS="WGS84" lat="52.04478805128214"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In_ret" id="dd50e603-c87c-4cdb-82bb-486ebee77255"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="ba9ca084-b71f-42a3-884a-f2f2b3ae4265" name="Out_ret" id="e31e12c2-8f80-4aed-9e4b-918445a32996"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe2_ret" id="Pipe2_ret" diameter="DN450" related="Pipe2" length="195.4" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe2" diameter="DN450" name="Pipe2_ret" length="195.4" id="Pipe2_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04211218475326" lon="4.308378045386691"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04280178836801" lon="4.311008661644606"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="ef74ea8c-89b4-42e0-a98c-411860876c1a" id="18ce6906-595c-45e4-acf0-e07f7d7648c6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="0431b8a0-a8d1-4375-b348-37a475add47a" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="bec83070-2c51-4825-82f3-92434bd3e59c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="1c33024c-99c8-4168-b353-9f099b59eb60" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="26fdb8bf-6413-4272-a56b-b084823ac574" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="1c33024c-99c8-4168-b353-9f099b59eb60">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="26fdb8bf-6413-4272-a56b-b084823ac574" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.308378045386691" CRS="WGS84" lat="52.04211218475326"/>
-          <point xsi:type="esdl:Point" lon="4.311008661644606" CRS="WGS84" lat="52.04280178836801"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="ef74ea8c-89b4-42e0-a98c-411860876c1a" name="In_ret" id="18ce6906-595c-45e4-acf0-e07f7d7648c6"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out_ret" id="0431b8a0-a8d1-4375-b348-37a475add47a"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe3_ret" id="Pipe3_ret" diameter="DN450" related="Pipe3" length="241.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe3" diameter="DN450" name="Pipe3_ret" length="241.6" id="Pipe3_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040874831021554" lon="4.312773152370705"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.0427984888545" lon="4.3111373978948455"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="2dd7961b-46ce-4027-84b6-cc2684a03a7b" id="0650d850-58a9-45b3-8313-a3156a061988" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="6b655eb1-2b66-455f-90a3-0dd6f2844fab" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="38f2f0f7-f814-4baf-ae3a-365af1b872db">
-          <investmentCosts xsi:type="esdl:SingleValue" id="78221659-7294-4830-802c-67e38364b1f0" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="19f63b61-453d-4213-bdc6-86f65468fec9" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="78221659-7294-4830-802c-67e38364b1f0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="19f63b61-453d-4213-bdc6-86f65468fec9" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.312773152370705" CRS="WGS84" lat="52.040874831021554"/>
-          <point xsi:type="esdl:Point" lon="4.3111373978948455" CRS="WGS84" lat="52.0427984888545"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2dd7961b-46ce-4027-84b6-cc2684a03a7b" name="In_ret" id="0650d850-58a9-45b3-8313-a3156a061988"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out_ret" id="6b655eb1-2b66-455f-90a3-0dd6f2844fab"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe4_ret" id="Pipe4_ret" diameter="DN450" related="Pipe4" length="189.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe4" diameter="DN450" name="Pipe4_ret" length="189.7" id="Pipe4_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.04016209972487" lon="4.310158519812684"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040851733426216" lon="4.312697980725036"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" id="d126f79e-c43e-4d9d-a7ce-8f58be634695" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="2a15456e-d23e-4064-8dee-c0588d3b05dc">
-          <investmentCosts xsi:type="esdl:SingleValue" id="0297b96a-c32c-41f8-8653-0085659dba29" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="9869b0d2-dfa3-4148-86ab-ddd1cb43b7c7" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="0297b96a-c32c-41f8-8653-0085659dba29">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="9869b0d2-dfa3-4148-86ab-ddd1cb43b7c7" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.310158519812684" CRS="WGS84" lat="52.04016209972487"/>
-          <point xsi:type="esdl:Point" lon="4.312697980725036" CRS="WGS84" lat="52.040851733426216"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="bf6e0b6b-baac-468b-a9ba-f8397babf5d6" name="In_ret" id="d126f79e-c43e-4d9d-a7ce-8f58be634695"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" name="Out_ret" id="b3187ef9-cd0b-4ea8-90e4-eab39fa225e9"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe5_ret" id="Pipe5_ret" diameter="DN450" related="Pipe5" length="244.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe5" diameter="DN450" name="Pipe5_ret" length="244.6" id="Pipe5_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.038888394199375" lon="4.314505162850188"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.040828635818976" lon="4.312826656948579"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="59ccdddc-893b-4152-8bc4-0168e7e74bf3" id="2b7c3acb-69a7-497d-a72f-b98db189841c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="4b3973ab-6e4b-48af-947d-52c6d30f20ea" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="387eb458-4e3e-4e0d-bf1c-0ca2d77aa4dd">
-          <investmentCosts xsi:type="esdl:SingleValue" id="b78ac8a7-9d0e-4603-821b-febf58b48bb3" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d6547801-0eb7-4ed4-9597-1e79cc093622" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="b78ac8a7-9d0e-4603-821b-febf58b48bb3">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d6547801-0eb7-4ed4-9597-1e79cc093622" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.314505162850188" CRS="WGS84" lat="52.038888394199375"/>
-          <point xsi:type="esdl:Point" lon="4.312826656948579" CRS="WGS84" lat="52.040828635818976"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="59ccdddc-893b-4152-8bc4-0168e7e74bf3" name="In_ret" id="2b7c3acb-69a7-497d-a72f-b98db189841c"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a1b719cb-f735-4a30-a0d2-cf6945b3afa1" name="Out_ret" id="4b3973ab-6e4b-48af-947d-52c6d30f20ea"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe6_ret" id="Pipe6_ret" diameter="DN450" related="Pipe6" length="176.6" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" related="Pipe6" diameter="DN450" name="Pipe6_ret" length="176.6" id="Pipe6_ret" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line">
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.03810303436292" lon="4.312174575996732"/>
+          <point xsi:type="esdl:Point" CRS="WGS84" lat="52.03884219694389" lon="4.314462105124955"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="9c025b19-57d1-43a8-b2e8-db3e684756f2" id="5cd0f2e0-d456-4909-a81c-4b312b1be857" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In_ret"/>
+        <port xsi:type="esdl:OutPort" id="2045aca9-4e50-42ec-99de-fbcffa627a86" connectedTo="f36b9767-8e64-4744-8cd0-08acb2ae873b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out_ret"/>
         <costInformation xsi:type="esdl:CostInformation" id="cbbb74ba-ba6f-4f17-a78f-3b3c07ce531d">
-          <investmentCosts xsi:type="esdl:SingleValue" id="ae5f4f5f-1323-4a3b-98c8-faca321a00c7" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="18570b20-b820-43d0-952a-b6eaf166c639" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" id="ae5f4f5f-1323-4a3b-98c8-faca321a00c7">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="18570b20-b820-43d0-952a-b6eaf166c639" description="Cost in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.312174575996732" CRS="WGS84" lat="52.03810303436292"/>
-          <point xsi:type="esdl:Point" lon="4.314462105124955" CRS="WGS84" lat="52.03884219694389"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="9c025b19-57d1-43a8-b2e8-db3e684756f2" name="In_ret" id="5cd0f2e0-d456-4909-a81c-4b312b1be857"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="f36b9767-8e64-4744-8cd0-08acb2ae873b" name="Out_ret" id="2045aca9-4e50-42ec-99de-fbcffa627a86"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe7_ret" id="Pipe7_ret" diameter="DN450" related="Pipe7" length="233.1" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="1eb6da23-b456-44fb-88a7-94ff025cee8f">
-          <investmentCosts xsi:type="esdl:SingleValue" id="9e6f7b4c-5be0-43f8-a75a-aa24c5ae0d00" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5709dcf7-d67d-437a-8d9d-6421a21b0bc0" description="Cost in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <geometry xsi:type="esdl:Line">
-          <point xsi:type="esdl:Point" lon="4.311074402665649" CRS="WGS84" lat="52.04281086202885"/>
-          <point xsi:type="esdl:Point" lon="4.314133518440636" CRS="WGS84" lat="52.04373884034295"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In_ret" id="c8973070-0f1d-455a-83a1-845eec60de2b"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="33a9041b-dd75-42c0-94a3-584c5e374927" name="Out_ret" id="42d7c2df-a85b-45bc-b2d9-b58f03dac573"/>
-      </asset>
-      <asset xsi:type="esdl:HeatProducer" state="OPTIONAL" power="50000000.0" name="HeatProducer_2" id="da00ddfc-cfa4-4f21-b5be-7c69d2bf53bb">
+      <asset xsi:type="esdl:HeatProducer" power="50000000.0" name="HeatProducer_2" id="da00ddfc-cfa4-4f21-b5be-7c69d2bf53bb" state="OPTIONAL">
+        <geometry xsi:type="esdl:Point" lon="4.311726093292237" CRS="WGS84" lat="52.04487621664103"/>
+        <port xsi:type="esdl:OutPort" id="886e5430-bec1-44e3-bab6-221c4518c810" connectedTo="bbfed830-071d-4d02-bddd-e709247c8337" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <port xsi:type="esdl:InPort" connectedTo="df6f89d0-7872-4891-934f-de407f6aa142" id="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
         <costInformation xsi:type="esdl:CostInformation" id="d59fe0c4-5156-4dcf-b259-6ac6855241c6">
-          <investmentCosts xsi:type="esdl:SingleValue" id="3633cd09-9f87-4d8d-a5f8-0431bab9576d" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88a009ff-0eeb-48b1-9eb3-60dba04b3e79" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" id="2b2f4b93-32c7-4f20-9723-5900cc76fe20" value="100000.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="b0975eef-2e13-4b7f-b89a-64a47183e8cc" unit="EURO" physicalQuantity="COST" description="Cost in EUR"/>
-          </installationCosts>
-          <variableOperationalCosts xsi:type="esdl:SingleValue" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9" value="6.0">
+          <variableOperationalCosts xsi:type="esdl:SingleValue" value="6.0" id="7a789b95-93bb-415b-abbd-4ecbb6ad60c9">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="c52334c9-bc5d-41f4-b93d-10e7b769f281" description="Cost in EUR/MWh" perUnit="WATTHOUR" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
           </variableOperationalCosts>
+          <investmentCosts xsi:type="esdl:SingleValue" value="100000.0" id="3633cd09-9f87-4d8d-a5f8-0431bab9576d">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="88a009ff-0eeb-48b1-9eb3-60dba04b3e79" description="Cost in EUR/MW" perUnit="WATT" perMultiplier="MEGA" unit="EURO" physicalQuantity="COST"/>
+          </investmentCosts>
+          <installationCosts xsi:type="esdl:SingleValue" value="100000.0" id="2b2f4b93-32c7-4f20-9723-5900cc76fe20">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="b0975eef-2e13-4b7f-b89a-64a47183e8cc" physicalQuantity="COST" description="Cost in EUR" unit="EURO"/>
+          </installationCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237" CRS="WGS84"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="bbfed830-071d-4d02-bddd-e709247c8337" name="Out" id="886e5430-bec1-44e3-bab6-221c4518c810"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="df6f89d0-7872-4891-934f-de407f6aa142" name="In" id="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_f6e5" id="f6e5a760-01d5-4341-bf15-b8d33b7bea50" diameter="DN450" length="239.7" innerDiameter="0.4444" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_f6e5" length="239.7" id="f6e5a760-01d5-4341-bf15-b8d33b7bea50" innerDiameter="0.4444" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311726093292237" lat="52.04487621664103"/>
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="886e5430-bec1-44e3-bab6-221c4518c810" id="bbfed830-071d-4d02-bddd-e709247c8337" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="f966bade-1fad-453f-8ec2-4062ec70bc7b" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="22fb2e85-7a81-4371-b6ab-6d5101b8ca45">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237"/>
-          <point xsi:type="esdl:Point" lat="52.042720861938854" lon="4.311695247888566"/>
-        </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="886e5430-bec1-44e3-bab6-221c4518c810" name="In" id="bbfed830-071d-4d02-bddd-e709247c8337"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="51852861-aeeb-461f-b8ec-08f000abc6dd" name="Out" id="f966bade-1fad-453f-8ec2-4062ec70bc7b"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
-          </component>
-        </material>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_f6e5_ret" id="0db91515-418a-4bcb-9d99-9047c1ca8bdf" diameter="DN450" length="233.9" innerDiameter="0.4444" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="7cbc9c32-3d7d-44e1-ab73-598459294f0c">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9" name="Combined investment and installation costs">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_f6e5_ret" length="233.9" id="0db91515-418a-4bcb-9d99-9047c1ca8bdf" innerDiameter="0.4444" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.04281086202885" lon="4.311074402665649"/>
-          <point xsi:type="esdl:Point" lat="52.04487621664103" lon="4.311726093292237"/>
+          <point xsi:type="esdl:Point" lon="4.311074402665649" lat="52.04281086202885"/>
+          <point xsi:type="esdl:Point" lon="4.311726093292237" lat="52.04487621664103"/>
         </geometry>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" name="In" id="42e9f86b-ea96-4992-bf3f-9cbae8a4a39c"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" name="Out" id="df6f89d0-7872-4891-934f-de407f6aa142"/>
+        <port xsi:type="esdl:InPort" connectedTo="2913e645-b027-429e-bf5d-22ace96a39fa" id="42e9f86b-ea96-4992-bf3f-9cbae8a4a39c" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="df6f89d0-7872-4891-934f-de407f6aa142" connectedTo="c7ed8915-ddd0-47f8-93d6-1dabfb5d320b" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" name="steel" thermalConductivity="52.15"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" name="PUR" thermalConductivity="0.027"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" name="HDPE" thermalConductivity="0.4"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="7cbc9c32-3d7d-44e1-ab73-598459294f0c">
+          <investmentCosts xsi:type="esdl:SingleValue" value="3417.9" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
       </asset>
       <asset xsi:type="esdl:HeatStorage" name="HeatStorage_74c1" id="74c13eed-9ca8-4247-bd72-a68e242d8e1b" maxDischargeRate="10000000.0" maxChargeRate="10000000.0" volume="500.0">
+        <geometry xsi:type="esdl:Point" lon="4.313871860504151" CRS="WGS84" lat="52.042658996032856"/>
+        <port xsi:type="esdl:InPort" connectedTo="636a1943-2289-4d57-a2dd-33aaa4f25b49" id="8c09b9ff-5070-4fbc-97fe-db7a501932dc" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="cc725203-e648-490f-a12d-91fa85ee58f2" connectedTo="a581c340-3cab-46b1-924f-c5ddc0120de6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="4e390bc0-04b9-4c38-af99-077d7836f877">
-          <investmentCosts xsi:type="esdl:SingleValue" id="40414844-ab63-452e-9558-057d61623ba9" value="690.0">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" perUnit="CUBIC_METRE" description="COST in EUR/m3" unit="EURO" physicalQuantity="COST" id="a95abc37-2285-4d68-88ad-dba3e1e8aaf9"/>
+          <investmentCosts xsi:type="esdl:SingleValue" value="690.0" id="40414844-ab63-452e-9558-057d61623ba9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="a95abc37-2285-4d68-88ad-dba3e1e8aaf9" description="COST in EUR/m3" perUnit="CUBIC_METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <geometry xsi:type="esdl:Point" lat="52.042658996032856" lon="4.313871860504151" CRS="WGS84"/>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="636a1943-2289-4d57-a2dd-33aaa4f25b49" name="In" id="8c09b9ff-5070-4fbc-97fe-db7a501932dc"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="a581c340-3cab-46b1-924f-c5ddc0120de6" name="Out" id="cc725203-e648-490f-a12d-91fa85ee58f2"/>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_9768" id="97684360-d920-45c2-a584-a092fdcf91f1" diameter="DN450" innerDiameter="0.4444" length="149.0" outerDiameter="0.63">
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_9768" id="97684360-d920-45c2-a584-a092fdcf91f1" innerDiameter="0.4444" length="149.0" outerDiameter="0.63">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+          <point xsi:type="esdl:Point" lon="4.313871860504151" lat="52.042658996032856"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="2e672d8b-ee9b-4c8b-8357-58ea984ae6be" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="636a1943-2289-4d57-a2dd-33aaa4f25b49" connectedTo="8c09b9ff-5070-4fbc-97fe-db7a501932dc" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
+          </component>
+        </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
         <costInformation xsi:type="esdl:CostInformation" id="6939255e-b8a1-4045-9739-74690c35fda4">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
         </costInformation>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
-        <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.042720861938854" lon="4.311695247888566"/>
-          <point xsi:type="esdl:Point" lat="52.042658996032856" lon="4.313871860504151"/>
-        </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" name="In" id="2e672d8b-ee9b-4c8b-8357-58ea984ae6be"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" connectedTo="8c09b9ff-5070-4fbc-97fe-db7a501932dc" name="Out" id="636a1943-2289-4d57-a2dd-33aaa4f25b49"/>
-        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
-          </component>
-          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
-          </component>
-        </material>
       </asset>
-      <asset xsi:type="esdl:Pipe" state="ENABLED" name="Pipe_9768_ret" id="3542e501-01ea-468b-9d4f-c1e7c67b43d9" diameter="DN450" innerDiameter="0.4444" length="192.1" outerDiameter="0.63">
-        <costInformation xsi:type="esdl:CostInformation" id="68394efa-f98e-4fbe-9418-b5975d7c0fe7">
-          <investmentCosts xsi:type="esdl:SingleValue" id="a40165e8-88bd-49b9-81d9-298812ac0170" name="Combined investment and installation costs" value="3417.9">
-            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" unit="EURO" physicalQuantity="COST"/>
-          </investmentCosts>
-        </costInformation>
-        <dataSource xsi:type="esdl:DataSource" name="Logstor Product Catalogue Version 2020.03" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf"/>
+      <asset xsi:type="esdl:Pipe" diameter="DN450" name="Pipe_9768_ret" id="3542e501-01ea-468b-9d4f-c1e7c67b43d9" innerDiameter="0.4444" length="192.1" outerDiameter="0.63">
         <geometry xsi:type="esdl:Line" CRS="WGS84">
-          <point xsi:type="esdl:Point" lat="52.042658996032856" lon="4.313871860504151"/>
-          <point xsi:type="esdl:Point" lat="52.04281086202885" lon="4.311074402665649"/>
+          <point xsi:type="esdl:Point" lon="4.313871860504151" lat="52.042658996032856"/>
+          <point xsi:type="esdl:Point" lon="4.311074402665649" lat="52.04281086202885"/>
         </geometry>
-        <port xsi:type="esdl:InPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="cc725203-e648-490f-a12d-91fa85ee58f2" name="In" id="a581c340-3cab-46b1-924f-c5ddc0120de6"/>
-        <port xsi:type="esdl:OutPort" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" name="Out" id="8271240c-cae3-4e81-8b36-d65302a4e6b4"/>
+        <port xsi:type="esdl:InPort" connectedTo="cc725203-e648-490f-a12d-91fa85ee58f2" id="a581c340-3cab-46b1-924f-c5ddc0120de6" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="8271240c-cae3-4e81-8b36-d65302a4e6b4" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
         <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
-            <matter xsi:type="esdl:Material" id="371c1d72-de35-4559-9b0e-47172e5d1d83" thermalConductivity="52.15" name="steel"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" name="steel" id="371c1d72-de35-4559-9b0e-47172e5d1d83"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0805">
-            <matter xsi:type="esdl:Material" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c" thermalConductivity="0.027" name="PUR"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" name="PUR" id="df30bd37-2fc4-4993-828f-1b7cf1e8202c"/>
           </component>
           <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.006">
-            <matter xsi:type="esdl:Material" id="f53de37b-a735-4b0d-b226-a6b722029a01" thermalConductivity="0.4" name="HDPE"/>
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" name="HDPE" id="f53de37b-a735-4b0d-b226-a6b722029a01"/>
           </component>
         </material>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="68394efa-f98e-4fbe-9418-b5975d7c0fe7">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="a40165e8-88bd-49b9-81d9-298812ac0170" value="3417.9">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="d0aebc76-201b-4b2d-81fe-55269fcefe3b" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN400" name="Pipe_8125" outerDiameter="0.63" id="81250990-a84d-47c5-b923-b087329d35f8" innerDiameter="0.3938" length="233.1">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.311695247888566" lat="52.042720861938854"/>
+          <point xsi:type="esdl:Point" lon="4.314751625061036" lat="52.04364884025295"/>
+        </geometry>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" id="ae32d30b-4e0d-4470-a4f0-4ba7bd258070" name="steel"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.1052">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" id="5d591b58-2cf8-4d94-91eb-be773e1c25ee" name="PUR"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0066">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" id="8a0279cc-afbf-46fb-a590-33960ce30613" name="HDPE"/>
+          </component>
+        </material>
+        <port xsi:type="esdl:InPort" connectedTo="c0eac4db-f5da-47f3-8202-8438d000bd32" id="d89aec21-40a8-4014-86ee-2aba9f3ccbe5" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="In"/>
+        <port xsi:type="esdl:OutPort" id="350d66d9-dea3-4a42-85e4-ec9e2c127444" connectedTo="33a9041b-dd75-42c0-94a3-584c5e374927" carrier="7b32e287-d775-480c-b317-64ffdacf12c9" name="Out"/>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="9180beaf-4b01-4d6d-9292-ce4434da40f9">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="566d3f26-f85a-48b4-b06a-5fd62ac6fa61" value="2840.6">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5b1085e4-5642-4c1d-aa7c-bfb7793d4e64" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Pipe" diameter="DN400" name="Pipe_8125_ret" outerDiameter="0.63" id="57872968-57f4-4702-a0d7-78987855e877" innerDiameter="0.3938" length="232.9">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lon="4.314354658126832" lat="52.04373462571976"/>
+          <point xsi:type="esdl:Point" lon="4.311237931251527" lat="52.042889961645"/>
+        </geometry>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0063">
+            <matter xsi:type="esdl:Material" thermalConductivity="52.15" id="ae32d30b-4e0d-4470-a4f0-4ba7bd258070" name="steel"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.1052">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.027" id="5d591b58-2cf8-4d94-91eb-be773e1c25ee" name="PUR"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0066">
+            <matter xsi:type="esdl:Material" thermalConductivity="0.4" id="8a0279cc-afbf-46fb-a590-33960ce30613" name="HDPE"/>
+          </component>
+        </material>
+        <port xsi:type="esdl:InPort" connectedTo="0117d26b-8ab1-44b5-afee-51702e431e52" id="3ec3a129-928e-4152-9f98-2baa194e66c4" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="In"/>
+        <port xsi:type="esdl:OutPort" id="b314b276-dcb4-4668-a337-5eef17ff164d" connectedTo="7893125d-d82f-4fe8-aaea-5fb6afecc635" carrier="7b32e287-d775-480c-b317-64ffdacf12c9_ret" name="Out"/>
+        <dataSource xsi:type="esdl:DataSource" attribution="https://www.logstor.com/media/6506/product-catalogue-uk-202003.pdf" name="Logstor Product Catalogue Version 2020.03"/>
+        <costInformation xsi:type="esdl:CostInformation" id="25cd514a-a4a7-4b3c-832e-69bd1544ec90">
+          <investmentCosts xsi:type="esdl:SingleValue" name="Combined investment and installation costs" id="566d3f26-f85a-48b4-b06a-5fd62ac6fa61" value="2840.6">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="5b1085e4-5642-4c1d-aa7c-bfb7793d4e64" description="Costs in EUR/m" perUnit="METRE" physicalQuantity="COST" unit="EURO"/>
+          </investmentCosts>
+        </costInformation>
       </asset>
     </area>
   </instance>

--- a/tests/test_ates.py
+++ b/tests/test_ates.py
@@ -23,8 +23,8 @@ class TestAtes(TestCase):
         stored_heat = results["ATES_033c.Stored_heat"]
         heat_loss = results["ATES_033c.Heat_loss"]
         heat_ates = results["ATES_033c.Heat_ates"]
-        summed_discharge = np.sum(np.clip(heat_ates, 0.0, np.inf))
-        summed_charge = np.abs(np.sum(np.clip(heat_ates, -np.inf, 0.0)))
+        summed_charge = np.sum(np.clip(heat_ates, 0.0, np.inf))
+        summed_discharge = np.abs(np.sum(np.clip(heat_ates, -np.inf, 0.0)))
 
         # Test if the heat loss is as expected
         coeff = solution.parameters(0)["ATES_033c.heat_loss_coeff"]

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -50,13 +50,13 @@ def heat_to_discharge_test(solution, results):
         dt = solution.parameters(0)[f"{d}.dT"]
         test.assertTrue(
             expr=all(
-                np.clip(results[f"{d}.Heat_ates"], 0.0, np.inf)
-                >= (np.clip(results[f"{d}.HeatIn.Q"], 0.0, np.inf) * rho * cp * dt - 1e-6)
+                np.clip(results[f"{d}.Heat_ates"], -np.inf, 0.0)
+                <= (np.clip(results[f"{d}.HeatIn.Q"], -np.inf, 0.0) * rho * cp * dt + 1e-6)
             )
         )
         np.testing.assert_allclose(
-            np.clip(results[f"{d}.Heat_ates"], -np.inf, 0.0),
-            np.clip(results[f"{d}.HeatIn.Q"], -np.inf, 0.0) * rho * cp * dt,
+            np.clip(results[f"{d}.Heat_ates"], 0.0, np.inf),
+            np.clip(results[f"{d}.HeatIn.Q"], 0.0, np.inf) * rho * cp * dt,
         )
 
     for p in solution.hot_pipes:
@@ -86,7 +86,7 @@ def energy_conservation_test(solution, results):
         energy_sum += results[f"{d}.Heat_source"]
 
     for d in solution.heat_network_components.get("ates", []):
-        energy_sum += results[f"{d}.Heat_ates"]
+        energy_sum -= results[f"{d}.Heat_ates"]
 
     for p in solution.heat_network_components.get("pipe", []):
         energy_sum -= np.ones(len(solution.times())) * results[f"{p}__hn_heat_loss"]


### PR DESCRIPTION
Changes the required direction of the hot-pipe connecting the ATES to be like a demand. Furthermore, sign of the Heat_ates variable is switched. Test cases adapeted and tests adapted