### PR TITLE
Bug fix: only write valid kpis for polygon areas

### DIFF
--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -459,30 +459,34 @@ class ScenarioOutput(HeatMixin):
 
             # Here we add KPIs to the polygon area which allows to visualize them by hoovering over
             # it with the mouse
-            kpis.kpi.append(
-                esdl.DoubleKPI(
-                    value=area_investment_cost / 1.0e6,
-                    name="Investment",
-                    quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                        physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                        unit=esdl.UnitEnum.EURO,
-                        multiplier=esdl.MultiplierEnum.MEGA,
-                    ),
+            # Only update kpis if one of the costs > 0, else esdl file will be corrupted
+            if area_investment_cost > 0.0 or area_installation_cost > 0.0:
+                kpis.kpi.append(
+                    esdl.DoubleKPI(
+                        value=area_investment_cost / 1.0e6,
+                        name="Investment",
+                        quantityAndUnit=esdl.esdl.QuantityAndUnitType(
+                            physicalQuantity=esdl.PhysicalQuantityEnum.COST,
+                            unit=esdl.UnitEnum.EURO,
+                            multiplier=esdl.MultiplierEnum.MEGA,
+                        ),
+                    )
                 )
-            )
-            kpis.kpi.append(
-                esdl.DoubleKPI(
-                    value=area_installation_cost / 1.0e6,
-                    name="Installation",
-                    quantityAndUnit=esdl.esdl.QuantityAndUnitType(
-                        physicalQuantity=esdl.PhysicalQuantityEnum.COST,
-                        unit=esdl.UnitEnum.EURO,
-                        multiplier=esdl.MultiplierEnum.MEGA,
-                    ),
+                kpis.kpi.append(
+                    esdl.DoubleKPI(
+                        value=area_installation_cost / 1.0e6,
+                        name="Installation",
+                        quantityAndUnit=esdl.esdl.QuantityAndUnitType(
+                            physicalQuantity=esdl.PhysicalQuantityEnum.COST,
+                            unit=esdl.UnitEnum.EURO,
+                            multiplier=esdl.MultiplierEnum.MEGA,
+                        ),
+                    )
                 )
-            )
-
-            if is_at_least_asset_opex_included:
+            # Only update kpis if one of the costs > 0, else esdl file will be corrupted
+            if is_at_least_asset_opex_included and (
+                area_variable_opex_cost > 0.0 or area_fixed_opex_cost > 0.0
+            ):
                 kpis.kpi.append(
                     esdl.DoubleKPI(
                         value=area_variable_opex_cost / 1.0e6,


### PR DESCRIPTION
- Write out only kpis if at least one cost value exists within a polygon area
- If no costs have been specified for assets in a polygon area, then no kpis will be shown when once hovers over the polygon area. However, in the bar charts the kpi values will be shown as 0.0