### PR TITLE
Simplify esdl parsing based on pyESDL_23.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "pyecore",
         "pymoca >= 0.9.0",
         "rtc-tools == 2.6.0a3",
-        "pyesdl >= 23.10.1",
+        "pyesdl >= 23.11",
         "pandas >= 1.3.1, < 2.0",
     ],
     tests_require=["pytest", "pytest-runner", "numpy"],

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "pyecore",
         "pymoca >= 0.9.0",
         "rtc-tools == 2.6.0a3",
-        "pyesdl >= 23.11",
+        "pyesdl >= 23.11.1",
         "pandas >= 1.3.1, < 2.0",
     ],
     tests_require=["pytest", "pytest-runner", "numpy"],

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "rtc-tools == 2.6.0a3",
         "pyesdl >= 23.11.1",
         "pandas >= 1.3.1, < 2.0",
+        "casadi == 3.6.3",
     ],
     tests_require=["pytest", "pytest-runner", "numpy"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "pyecore",
         "pymoca >= 0.9.0",
         "rtc-tools == 2.6.0a3",
-        "pyesdl >= 21.11.0",
+        "pyesdl >= 23.10.1",
         "pandas >= 1.3.1, < 2.0",
     ],
     tests_require=["pytest", "pytest-runner", "numpy"],

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from datetime import timedelta as td
 
 import esdl
@@ -124,6 +125,19 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
             profile.startDate,
             profile.endDate,
         )
+        # Error check: ensure that the profile data has a time resolutuon of 3600s (1hour) as
+        # expected
+        for idp in range(len(time_series_data.profile_data_list) - 1):
+            time_resolution = (
+                time_series_data.profile_data_list[idp + 1][0]
+                - time_series_data.profile_data_list[idp][0]
+            )
+            if time_resolution.seconds != 3600:
+                logger.error(
+                    f"The time resolution of the profile:{profile.measurement}-{profile.field} is"
+                    "not 3600s as expected"
+                )
+                sys.exit(1)
 
         data_points = {
             t[0].strftime("%Y-%m-%dT%H:%M:%SZ"): t[1] for t in time_series_data.profile_data_list

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -5,6 +5,8 @@ from datetime import timedelta as td
 import esdl
 from esdl.profiles.influxdbprofilemanager import ConnectionSettings
 from esdl.profiles.influxdbprofilemanager import InfluxDBProfileManager
+from esdl.units.conversion import ENERGY_IN_J, POWER_IN_W, convert_to_unit
+
 
 import pandas as pd
 
@@ -16,73 +18,73 @@ time_step = td(seconds=3600)
 time_step_notation = "{}s".format(int(time_step.total_seconds()))
 
 
-def get_mw_multiplier(profile: esdl.GenericProfile):
-    ts = time_step.total_seconds()
-    factor = {
-        "ENERGY_IN_WH": 3.6 / (1e3 * ts),
-        "ENERGY_IN_KWH": 3.6 / ts,
-        "ENERGY_IN_MWH": (3.6 * 1e3) / ts,
-        "ENERGY_IN_GWH": (3.6 * 1e6) / ts,
-        "ENERGY_IN_TWH": (3.6 * 1e9) / ts,
-        "ENERGY_IN_PWH": (3.6 * 1e12) / ts,
-        "ENERGY_IN_J": 1 / (1e6 * ts),
-        "ENERGY_IN_KJ": 1 / (1e3 * ts),
-        "ENERGY_IN_MJ": 1 / ts,
-        "ENERGY_IN_GJ": 1e3 / ts,
-        "ENERGY_IN_TJ": 1e6 / ts,
-        "ENERGY_IN_PJ": 1e9 / ts,
-        "POWER_IN_W": 1 / 1e6,
-        "POWER_IN_KW": 1 / 1e3,
-        "POWER_IN_MW": 1,
-        "POWER_IN_GW": 1e3,
-        "POWER_IN_TW": 1e6,
-        "POWER_IN_PW": 1e9,
-    }
+# def get_mw_multiplier(profile: esdl.GenericProfile):
+#     ts = time_step.total_seconds()
+#     factor = {
+#         "ENERGY_IN_WH": 3.6 / (1e3 * ts),
+#         "ENERGY_IN_KWH": 3.6 / ts,
+#         "ENERGY_IN_MWH": (3.6 * 1e3) / ts,
+#         "ENERGY_IN_GWH": (3.6 * 1e6) / ts,
+#         "ENERGY_IN_TWH": (3.6 * 1e9) / ts,
+#         "ENERGY_IN_PWH": (3.6 * 1e12) / ts,
+#         "ENERGY_IN_J": 1 / (1e6 * ts),
+#         "ENERGY_IN_KJ": 1 / (1e3 * ts),
+#         "ENERGY_IN_MJ": 1 / ts,
+#         "ENERGY_IN_GJ": 1e3 / ts,
+#         "ENERGY_IN_TJ": 1e6 / ts,
+#         "ENERGY_IN_PJ": 1e9 / ts,
+#         "POWER_IN_W": 1 / 1e6,
+#         "POWER_IN_KW": 1 / 1e3,
+#         "POWER_IN_MW": 1,
+#         "POWER_IN_GW": 1e3,
+#         "POWER_IN_TW": 1e6,
+#         "POWER_IN_PW": 1e9,
+#     }
 
-    mult_suffix = {
-        "NONE": "",
-        "KILO": "K",
-        "MEGA": "M",
-        "GIGA": "G",
-        "TERRA": "T",
-        "PETA": "P",
-        "MILLI": "-",
-        "MICRO": "-",
-        "NANO": "-",
-        "PICO": "-",
-    }
+#     mult_suffix = {
+#         "NONE": "",
+#         "KILO": "K",
+#         "MEGA": "M",
+#         "GIGA": "G",
+#         "TERRA": "T",
+#         "PETA": "P",
+#         "MILLI": "-",
+#         "MICRO": "-",
+#         "NANO": "-",
+#         "PICO": "-",
+#     }
 
-    if profile.profileType is not None and profile.profileType != esdl.ProfileTypeEnum.UNDEFINED:
-        if profile.profileType.name not in factor:
-            print("Unsupported profile type : {}".format(profile.profileType))
-            return 0
-        return factor[profile.profileType.name]
+#     if profile.profileType is not None and profile.profileType != esdl.ProfileTypeEnum.UNDEFINED:
+#         if profile.profileType.name not in factor:
+#             print("Unsupported profile type : {}".format(profile.profileType))
+#             return 0
+#         return factor[profile.profileType.name]
 
-    if isinstance(profile.profileQuantityAndUnit, esdl.QuantityAndUnitReference):
-        p = profile.profileQuantityAndUnit.reference
-    elif isinstance(profile.profileQuantityAndUnit, esdl.QuantityAndUnitType):
-        p = profile.profileQuantityAndUnit
+#     if isinstance(profile.profileQuantityAndUnit, esdl.QuantityAndUnitReference):
+#         p = profile.profileQuantityAndUnit.reference
+#     elif isinstance(profile.profileQuantityAndUnit, esdl.QuantityAndUnitType):
+#         p = profile.profileQuantityAndUnit
 
-    if p is not None:
-        if p.unit == esdl.UnitEnum.JOULE:
-            phy_quantity = "ENERGY_IN_"
-            suffix = "J"
-        elif p.unit == esdl.UnitEnum.WATTHOUR:
-            phy_quantity = "ENERGY_IN_"
-            suffix = "WH"
-        elif p.unit == esdl.UnitEnum.WATT:
-            phy_quantity = "POWER_IN_"
-            suffix = "W"
-        else:
-            print("Unsupported unit : {}".format(p.unit))
-            return 0
+#     if p is not None:
+#         if p.unit == esdl.UnitEnum.JOULE:
+#             phy_quantity = "ENERGY_IN_"
+#             suffix = "J"
+#         elif p.unit == esdl.UnitEnum.WATTHOUR:
+#             phy_quantity = "ENERGY_IN_"
+#             suffix = "WH"
+#         elif p.unit == esdl.UnitEnum.WATT:
+#             phy_quantity = "POWER_IN_"
+#             suffix = "W"
+#         else:
+#             print("Unsupported unit : {}".format(p.unit))
+#             return 0
 
-        prefix = mult_suffix[p.multiplier.name]
-        if prefix == "-":
-            print("Unsupported multiplier : {}".format(p.multiplier))
-            return 0
+#         prefix = mult_suffix[p.multiplier.name]
+#         if prefix == "-":
+#             print("Unsupported multiplier : {}".format(p.multiplier))
+#             return 0
 
-        return factor["{}{}{}".format(phy_quantity, prefix, suffix)]
+#         return factor["{}{}{}".format(phy_quantity, prefix, suffix)]
 
 
 def parse_esdl_profiles(es, start_date=None, end_date=None):
@@ -91,7 +93,8 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
     for profile in [x for x in es.eAllContents() if isinstance(x, esdl.InfluxDBProfile)]:
         profile_host = profile.host
         containing_asset_id = profile.eContainer().energyasset.id
-        to_mw_multiplier = get_mw_multiplier(profile)
+        # to_mw_multiplier = get_mw_multiplier(profile)
+
         ssl_setting = False
         if "https" in profile_host:
             profile_host = profile_host[8:]
@@ -144,7 +147,38 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
         }
         df = pd.DataFrame.from_dict(data_points, orient="index")
         df.index = pd.to_datetime(df.index, utc=True)
-        data_set[containing_asset_id] = df * profile.multiplier * to_mw_multiplier * 1.0e6
+        # TODO: remove old code below once test case with profiles have been included
+        # data_set[containing_asset_id] = df * profile.multiplier * to_mw_multiplier * 1.0e6
+
+        # TODO add test case. Currently no test case for esdl parsing
+        # Convert Power and Energy to standard unit of Watt and Joules
+        # Note: at the time of this code below being implemented pyESDL catered for limited
+        # power/energy units which is in the process of being expanded
+        for idf in range(len(df)):
+            if (
+                profile.profileQuantityAndUnit.reference.physicalQuantity
+                == esdl.PhysicalQuantityEnum.POWER
+            ):
+                df.iloc[idf] = convert_to_unit(
+                    df.iloc[idf], profile.profileQuantityAndUnit, POWER_IN_W
+                )
+            elif (
+                profile.profileQuantityAndUnit.reference.physicalQuantity
+                == esdl.PhysicalQuantityEnum.ENERGY
+            ):
+                df.iloc[idf] = convert_to_unit(
+                    df.iloc[idf], profile.profileQuantityAndUnit, ENERGY_IN_J
+                )
+            else:
+                print(
+                    f"Current the code only caters for: {esdl.PhysicalQuantityEnum.POWER} & "
+                    f"{esdl.PhysicalQuantityEnum.ENERGY}, and it does not cater for "
+                    f"{profile.profileQuantityAndUnit.reference.physicalQuantity}"
+                )
+                sys.exit(1)
+
+        data_set[containing_asset_id] = df * profile.multiplier
+
         if len(error_neighbourhoods) > 0:
             raise RuntimeError(f"Encountered errors loading data for {error_neighbourhoods}")
 

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -18,82 +18,12 @@ time_step = td(seconds=3600)
 time_step_notation = "{}s".format(int(time_step.total_seconds()))
 
 
-# def get_mw_multiplier(profile: esdl.GenericProfile):
-#     ts = time_step.total_seconds()
-#     factor = {
-#         "ENERGY_IN_WH": 3.6 / (1e3 * ts),
-#         "ENERGY_IN_KWH": 3.6 / ts,
-#         "ENERGY_IN_MWH": (3.6 * 1e3) / ts,
-#         "ENERGY_IN_GWH": (3.6 * 1e6) / ts,
-#         "ENERGY_IN_TWH": (3.6 * 1e9) / ts,
-#         "ENERGY_IN_PWH": (3.6 * 1e12) / ts,
-#         "ENERGY_IN_J": 1 / (1e6 * ts),
-#         "ENERGY_IN_KJ": 1 / (1e3 * ts),
-#         "ENERGY_IN_MJ": 1 / ts,
-#         "ENERGY_IN_GJ": 1e3 / ts,
-#         "ENERGY_IN_TJ": 1e6 / ts,
-#         "ENERGY_IN_PJ": 1e9 / ts,
-#         "POWER_IN_W": 1 / 1e6,
-#         "POWER_IN_KW": 1 / 1e3,
-#         "POWER_IN_MW": 1,
-#         "POWER_IN_GW": 1e3,
-#         "POWER_IN_TW": 1e6,
-#         "POWER_IN_PW": 1e9,
-#     }
-
-#     mult_suffix = {
-#         "NONE": "",
-#         "KILO": "K",
-#         "MEGA": "M",
-#         "GIGA": "G",
-#         "TERRA": "T",
-#         "PETA": "P",
-#         "MILLI": "-",
-#         "MICRO": "-",
-#         "NANO": "-",
-#         "PICO": "-",
-#     }
-
-#     if profile.profileType is not None and profile.profileType != esdl.ProfileTypeEnum.UNDEFINED:
-#         if profile.profileType.name not in factor:
-#             print("Unsupported profile type : {}".format(profile.profileType))
-#             return 0
-#         return factor[profile.profileType.name]
-
-#     if isinstance(profile.profileQuantityAndUnit, esdl.QuantityAndUnitReference):
-#         p = profile.profileQuantityAndUnit.reference
-#     elif isinstance(profile.profileQuantityAndUnit, esdl.QuantityAndUnitType):
-#         p = profile.profileQuantityAndUnit
-
-#     if p is not None:
-#         if p.unit == esdl.UnitEnum.JOULE:
-#             phy_quantity = "ENERGY_IN_"
-#             suffix = "J"
-#         elif p.unit == esdl.UnitEnum.WATTHOUR:
-#             phy_quantity = "ENERGY_IN_"
-#             suffix = "WH"
-#         elif p.unit == esdl.UnitEnum.WATT:
-#             phy_quantity = "POWER_IN_"
-#             suffix = "W"
-#         else:
-#             print("Unsupported unit : {}".format(p.unit))
-#             return 0
-
-#         prefix = mult_suffix[p.multiplier.name]
-#         if prefix == "-":
-#             print("Unsupported multiplier : {}".format(p.multiplier))
-#             return 0
-
-#         return factor["{}{}{}".format(phy_quantity, prefix, suffix)]
-
-
 def parse_esdl_profiles(es, start_date=None, end_date=None):
     logger.info("Caching profiles...")
     error_neighbourhoods = list()
     for profile in [x for x in es.eAllContents() if isinstance(x, esdl.InfluxDBProfile)]:
         profile_host = profile.host
         containing_asset_id = profile.eContainer().energyasset.id
-        # to_mw_multiplier = get_mw_multiplier(profile)
 
         ssl_setting = False
         if "https" in profile_host:
@@ -180,8 +110,6 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
         }
         df = pd.DataFrame.from_dict(data_points, orient="index")
         df.index = pd.to_datetime(df.index, utc=True)
-        # TODO: remove old code below once test case with profiles have been included
-        # data_set[containing_asset_id] = df * profile.multiplier * to_mw_multiplier * 1.0e6
 
         # TODO add test case. Currently no test case for esdl parsing
         # Convert Power and Energy to standard unit of Watt and Joules

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -118,14 +118,11 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
         )
         time_series_data = InfluxDBProfileManager(conn_settings)
 
-        # TODO: to be resolve the need for this line of code below - Edwin
-        end_date = profile.endDate.replace(hour=profile.endDate.hour + 1)
-
         time_series_data.load_influxdb(
             '"' + profile.measurement + '"',
             [profile.field],
             profile.startDate,
-            end_date,
+            profile.endDate,
         )
 
         data_points = {

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -128,6 +128,39 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
             profile.startDate,
             profile.endDate,
         )
+
+        # Error check start and end dates of profiles
+        # TODO: uncomment code below once pyESDL bug has been resolved
+        # if time_series_data.end_datetime != profile.endDate:
+        #     logger.error(
+        #         f"The user input profile end datetime: {profile.endDate} does not match the end"
+        #         f" datetime in the datbase: {time_series_data.end_datetime} for variable: "
+        #         f"{profile.field}"
+        #     )
+        #     sys.exit(1)
+        if time_series_data.start_datetime != profile.startDate:
+            logger.error(
+                f"The user input profile start datetime: {profile.startDate} does not match the"
+                f" start date in the datbase: {time_series_data.start_datetime} for variable: "
+                f"{profile.field}"
+            )
+            sys.exit(1)
+        if time_series_data.start_datetime != time_series_data.profile_data_list[0][0]:
+            logger.error(
+                f"The profile's variable value for the start datetime: "
+                f"{time_series_data.start_datetime} does not match the start datetime of the"
+                f" profile data: {time_series_data.profile_data_list[0][0]}"
+            )
+            sys.exit(1)
+        # TODO: uncomment code below once pyESDL bug has been resolved
+        # if time_series_data.end_datetime != time_series_data.profile_data_list[-1][0]:
+        #     logger.error(
+        #         f"The profile's variable value for the end datetime: "
+        #         f"{time_series_data.end_datetime} does not match the end datetime of the"
+        #         f" profile data: {time_series_data.profile_data_list[-1][0]}"
+        #     )
+        #     sys.exit(1)
+
         # Error check: ensure that the profile data has a time resolutuon of 3600s (1hour) as
         # expected
         for idp in range(len(time_series_data.profile_data_list) - 1):

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -91,7 +91,14 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
         profile_host = profile.host
         containing_asset_id = profile.eContainer().energyasset.id
         to_mw_multiplier = get_mw_multiplier(profile)
-        ssl_setting = True
+        ssl_setting = False
+        if "https" in profile_host:
+            profile_host = profile_host[8:]
+            ssl_setting = True
+        elif "http" in profile_host:
+            profile_host = profile_host[7:]
+        if profile.port == 443:
+            ssl_setting = True
         profile_host = profile_host[8:]
         influx_host = "{}:{}".format(profile_host, profile.port)
         if influx_host in influx_cred_map:

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -152,8 +152,6 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
 
         # TODO add test case. Currently no test case for esdl parsing
         # Convert Power and Energy to standard unit of Watt and Joules
-        # Note: at the time of this code below being implemented pyESDL catered for limited
-        # power/energy units which is in the process of being expanded
         for idf in range(len(df)):
             if (
                 profile.profileQuantityAndUnit.reference.physicalQuantity

--- a/src/rtctools_heat_network/influxdb/profile.py
+++ b/src/rtctools_heat_network/influxdb/profile.py
@@ -60,14 +60,13 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
         )
 
         # Error check start and end dates of profiles
-        # TODO: uncomment code below once pyESDL bug has been resolved
-        # if time_series_data.end_datetime != profile.endDate:
-        #     logger.error(
-        #         f"The user input profile end datetime: {profile.endDate} does not match the end"
-        #         f" datetime in the datbase: {time_series_data.end_datetime} for variable: "
-        #         f"{profile.field}"
-        #     )
-        #     sys.exit(1)
+        if time_series_data.end_datetime != profile.endDate:
+            logger.error(
+                f"The user input profile end datetime: {profile.endDate} does not match the end"
+                f" datetime in the datbase: {time_series_data.end_datetime} for variable: "
+                f"{profile.field}"
+            )
+            sys.exit(1)
         if time_series_data.start_datetime != profile.startDate:
             logger.error(
                 f"The user input profile start datetime: {profile.startDate} does not match the"
@@ -82,14 +81,13 @@ def parse_esdl_profiles(es, start_date=None, end_date=None):
                 f" profile data: {time_series_data.profile_data_list[0][0]}"
             )
             sys.exit(1)
-        # TODO: uncomment code below once pyESDL bug has been resolved
-        # if time_series_data.end_datetime != time_series_data.profile_data_list[-1][0]:
-        #     logger.error(
-        #         f"The profile's variable value for the end datetime: "
-        #         f"{time_series_data.end_datetime} does not match the end datetime of the"
-        #         f" profile data: {time_series_data.profile_data_list[-1][0]}"
-        #     )
-        #     sys.exit(1)
+        if time_series_data.end_datetime != time_series_data.profile_data_list[-1][0]:
+            logger.error(
+                f"The profile's variable value for the end datetime: "
+                f"{time_series_data.end_datetime} does not match the end datetime of the"
+                f" profile data: {time_series_data.profile_data_list[-1][0]}"
+            )
+            sys.exit(1)
 
         # Error check: ensure that the profile data has a time resolutuon of 3600s (1hour) as
         # expected

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -450,21 +450,8 @@ class EndScenarioSizingHIGHS(EndScenarioSizing):
         #             "fields": fields
         #         })
         # client.write_points(points=json_body, database=DB_NAME, batch_size=100)
-        connection_settings_influxdb = {
-            "host": "localhost",
-            "port": 8086,
-            "username": None,
-            "password": None,
-            "database": "pyesdl_test",
-            "ssl": False,
-            "verify_ssl": False,
-        }
 
-        self._write_updated_esdl(
-            db_profiles=False,
-            write_result_db_profiles=True,
-            db_connection_settings=connection_settings_influxdb,
-        )
+        self._write_updated_esdl(db_profiles=False)
 
     def solver_options(self):
         options = super().solver_options()
@@ -531,10 +518,23 @@ class EndScenarioSizingCBC(EndScenarioSizing):
 @main_decorator
 def main(runinfo_path, log_level):
     logger.info("Run Scenario Sizing")
+
+    kwargs = {
+        "write_result_db_profiles": False,
+        "influxdb_host": "localhost",
+        "influxdb_port": 8086,
+        "influxdb_username": None,
+        "influxdb_password": None,
+        "influxdb_database": "grow_workflow_test",
+        "influxdb_ssl": False,
+        "influxdb_verify_ssl": False,
+    }
+
     _ = run_optimization_problem(
         EndScenarioSizingHIGHS,
         esdl_run_info_path=runinfo_path,
         log_level=log_level,
+        **kwargs,
     )
 
     # results = solution.extract_results()

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -438,36 +438,6 @@ class EndScenarioSizingCBC(EndScenarioSizing):
     def post(self):
         super().post()
 
-        # results = self.extract_results()
-        # client = connect_database()
-        #
-        # json_body = []
-        #
-        # for asset in [*self.heat_network_components.get("source", []),
-        #               *self.heat_network_components.get("demand", []),
-        #               *self.heat_network_components.get("pipe", []),
-        #               *self.heat_network_components.get("buffer", []),
-        #               *self.heat_network_components.get("ates", []),
-        #               *self.heat_network_components.get("heat_exchanger", []),
-        #               *self.heat_network_components.get("heat_pump", [])]:
-        #     for i in range(len(self.times())):
-        #         fields = {}
-        #         try:
-        #             # For all components dealing with one hydraulic system
-        #             for variable in ["Heat_flow", "HeatIn.Q", "HeatIn.H"]:
-        #                 fields[variable] = results[f"{asset}." + variable][i]
-        #         except Exception:
-        #             # For all components dealing with two hydraulic system
-        #             for variable in ["Heat_flow", "Primary.HeatIn.Q", "Primary.HeatIn.H",
-        #                              "Secondary.HeatIn.Q", "Secondary.HeatIn.H"]:
-        #                 fields[variable] = results[f"{asset}." + variable][i]
-        #
-        #         json_body.append({
-        #             "measurement": asset,
-        #             "time": format_datetime(self.io.datetimes[i].strftime('%Y-%m-%d %H:%M')),
-        #             "fields": fields
-        #         })
-        # client.write_points(points=json_body, database=DB_NAME, batch_size=100)
         self._write_updated_esdl()
 
     def solver_options(self):

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -420,37 +420,6 @@ class EndScenarioSizingHIGHS(EndScenarioSizing):
     def post(self):
         super().post()
 
-        # results = self.extract_results()
-        # client = connect_database()
-        #
-        # json_body = []
-        #
-        # for asset in [*self.heat_network_components.get("source", []),
-        #               *self.heat_network_components.get("demand", []),
-        #               *self.heat_network_components.get("pipe", []),
-        #               *self.heat_network_components.get("buffer", []),
-        #               *self.heat_network_components.get("ates", []),
-        #               *self.heat_network_components.get("heat_exchanger", []),
-        #               *self.heat_network_components.get("heat_pump", [])]:
-        #     for i in range(len(self.times())):
-        #         fields = {}
-        #         try:
-        #             # For all components dealing with one hydraulic system
-        #             for variable in ["Heat_flow", "HeatIn.Q", "HeatIn.H"]:
-        #                 fields[variable] = results[f"{asset}." + variable][i]
-        #         except Exception:
-        #             # For all components dealing with two hydraulic system
-        #             for variable in ["Heat_flow", "Primary.HeatIn.Q", "Primary.HeatIn.H",
-        #                              "Secondary.HeatIn.Q", "Secondary.HeatIn.H"]:
-        #                 fields[variable] = results[f"{asset}." + variable][i]
-        #
-        #         json_body.append({
-        #             "measurement": asset,
-        #             "time": format_datetime(self.io.datetimes[i].strftime('%Y-%m-%d %H:%M')),
-        #             "fields": fields
-        #         })
-        # client.write_points(points=json_body, database=DB_NAME, batch_size=100)
-
         self._write_updated_esdl()
 
     def solver_options(self):

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -464,7 +464,6 @@ def main(runinfo_path, log_level):
         "influxdb_port": 8086,
         "influxdb_username": None,
         "influxdb_password": None,
-        "influxdb_database": "grow_workflow_test",
         "influxdb_ssl": False,
         "influxdb_verify_ssl": False,
     }

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -450,7 +450,21 @@ class EndScenarioSizingHIGHS(EndScenarioSizing):
         #             "fields": fields
         #         })
         # client.write_points(points=json_body, database=DB_NAME, batch_size=100)
-        self._write_updated_esdl(db_profiles=False)
+        connection_settings_influxdb = {
+            "host": "localhost",
+            "port": 8086,
+            "username": None,
+            "password": None,
+            "database": "pyesdl_test",
+            "ssl": False,
+            "verify_ssl": False,
+        }
+
+        self._write_updated_esdl(
+            db_profiles=False,
+            write_result_db_profiles=True,
+            db_connection_settings=connection_settings_influxdb,
+        )
 
     def solver_options(self):
         options = super().solver_options()

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -451,7 +451,7 @@ class EndScenarioSizingHIGHS(EndScenarioSizing):
         #         })
         # client.write_points(points=json_body, database=DB_NAME, batch_size=100)
 
-        self._write_updated_esdl(db_profiles=False)
+        self._write_updated_esdl()
 
     def solver_options(self):
         options = super().solver_options()
@@ -499,7 +499,7 @@ class EndScenarioSizingCBC(EndScenarioSizing):
         #             "fields": fields
         #         })
         # client.write_points(points=json_body, database=DB_NAME, batch_size=100)
-        self._write_updated_esdl(db_profiles=False)
+        self._write_updated_esdl()
 
     def solver_options(self):
         options = super().solver_options()

--- a/src/rtctools_heat_network/workflows/io/read_files_and_create_influxdb.py
+++ b/src/rtctools_heat_network/workflows/io/read_files_and_create_influxdb.py
@@ -1,0 +1,52 @@
+import glob
+import os
+
+from esdl.profiles.excelprofilemanager import ExcelProfileManager
+from esdl.profiles.influxdbprofilemanager import ConnectionSettings
+from esdl.profiles.influxdbprofilemanager import InfluxDBProfileManager
+
+"""
+Place raw excel files in fodler: raw_data_files_folder
+Database definition:
+
+Database name: input esdl id
+Measurement: asset name
+Fields: Variables per asset
+Tags/fiters: {tag: "output_esdl_id, value: id}
+"""
+
+# Settings for the reading excel files and creating a influxDB
+raw_data_files_folder = "C:\\Projects_gitlab\\database_files_test\\"
+input_energy_system_id = "15174819-d1af-4ba6-9f1d-2cd07991f14a"
+output_energy_system_id = "a33fe8db-8bdb-45a0-b1e7-69c348001672"
+influxdb_conn_settings = ConnectionSettings(
+    host="localhost",
+    port=8086,
+    username=None,
+    password=None,
+    database=input_energy_system_id,
+    ssl=False,
+    verify_ssl=False,
+)
+optim_simulation_tag = {"output_esdl_id": output_energy_system_id}
+
+excel_files = glob.glob(os.path.join(raw_data_files_folder, "*.xlsx"))
+
+
+for file in excel_files:
+
+    print("Read data from Excel")
+    excel_prof_read = ExcelProfileManager()
+    excel_prof_read.load_excel(file)
+
+    print("Create database")
+    influxdb_profile_manager_create_new = InfluxDBProfileManager(
+        influxdb_conn_settings, excel_prof_read
+    )
+    asset_name = file.split("\\")[-1].replace(".xlsx", "")
+    _ = influxdb_profile_manager_create_new.save_influxdb(
+        measurement=asset_name,
+        field_names=influxdb_profile_manager_create_new.profile_header[1:],
+        tags=optim_simulation_tag,
+    )
+    test = 0.0

--- a/src/rtctools_heat_network/workflows/io/read_files_and_create_influxdb.py
+++ b/src/rtctools_heat_network/workflows/io/read_files_and_create_influxdb.py
@@ -34,7 +34,6 @@ excel_files = glob.glob(os.path.join(raw_data_files_folder, "*.xlsx"))
 
 
 for file in excel_files:
-
     print("Read data from Excel")
     excel_prof_read = ExcelProfileManager()
     excel_prof_read.load_excel(file)
@@ -49,4 +48,3 @@ for file in excel_files:
         field_names=influxdb_profile_manager_create_new.profile_header[1:],
         tags=optim_simulation_tag,
     )
-    test = 0.0

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -857,9 +857,11 @@ class ScenarioOutput(HeatMixin):
             )
 
             influxdb_profile_manager = InfluxDBProfileManager(conn_settings, profiles)
+            # tags = {"region": "us-west"}  # test tags
             _ = influxdb_profile_manager.save_influxdb(
                 measurement=energy_system.id,
                 field_names=influxdb_profile_manager.profile_header[1:],
+                # tags=tags,
             )
             # TODO: create test case
             # Code that can be used to remove a specific measurment from the database
@@ -890,6 +892,18 @@ class ScenarioOutput(HeatMixin):
             # # np.testing.assert_array_equal(ts_prof.values[2], 5.6)
             # # np.testing.assert_array_equal(ts_prof.values[3], 1.2)
             # # np.testing.assert_array_equal(len(ts_prof.values), 4)
+
+            # Test tags
+            # prof3 = InfluxDBProfileManager(conn_settings)
+            # dicts = [{"tag": "region", "value": "us-west"}]
+            # prof3.load_influxdb(
+            #     '"' + energy_system.id + '"' , ["ResidualHeatSource_72d7_HeatIn.Q"],
+            #     profiles.start_datetime,
+            #     profiles.end_datetime,
+            #     dicts,
+            # )
+            # test = 0.0
+            
 
         # ------------------------------------------------------------------------------------------
         # Save esdl file

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -783,6 +783,25 @@ class ScenarioOutput(HeatMixin):
                         # If the asset has been placed
                         asset = _name_to_asset(asset_name)
 
+                        # Get index of outport which will be used to assign the profile data to
+                        index_outport = -1
+                        for ip in range(len(asset.port)):
+                            if asset.port[ip].name == "Out":
+                                if index_outport == -1:
+                                    index_outport = ip
+                                else:
+                                    logger.error(
+                                        f"Asset {asset_name} has more than 1 outport, which is"
+                                        "intended for use to assign result profile data to"
+                                    )
+                                    sys.exit(1)
+                        if index_outport == -1:
+                            logger.error(
+                                f"Variable {index_outport} has not been assigned to the asset"
+                                "outport"
+                            )
+                            sys.exit(1)
+
                         try:
                             # For all components dealing with one hydraulic system
                             if isinstance(
@@ -811,7 +830,7 @@ class ScenarioOutput(HeatMixin):
                                     port=self.influxdb_port,
                                     host=self.influxdb_host,
                                 )
-                                asset.port[1].profile.append(profile_attributes)
+                                asset.port[index_outport].profile.append(profile_attributes)
 
                             # Add variable values in new column
                             data_row.append(results[f"{asset_name}." + variable][ii])

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -746,9 +746,8 @@ class ScenarioOutput(HeatMixin):
         #   - Database name: input esdl id
         #   - Measurment: asset name
         #   - Fields: profile value for the specific variable
-        #  - The database contains a measurement (used esdl energy system id as the name for this),
-        #    which is a table of the profile results. The each time step is represented by a row of
-        #    data, and the columns are: datetime, asset name + "_" variable value
+        #   - Tags used as filters: output esdl id
+
         if self.write_result_db_profiles:
             logger.info("Writing asset result profile data to influxDB")
             results = self.extract_results()

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -10,6 +10,8 @@ from esdl.profiles.influxdbprofilemanager import ConnectionSettings
 from esdl.profiles.influxdbprofilemanager import InfluxDBProfileManager
 from esdl.profiles.profilemanager import ProfileManager
 
+# from esdl.profiles.excelprofilemanager import ExcelProfileManager
+
 import numpy as np
 
 import pandas as pd
@@ -17,6 +19,7 @@ import pandas as pd
 from rtctools_heat_network.esdl.edr_pipe_class import EDRPipeClass
 from rtctools_heat_network.heat_mixin import HeatMixin
 from rtctools_heat_network.workflows.utils.helpers import _sort_numbered
+
 
 logger = logging.getLogger("rtctools_heat_network")
 
@@ -850,24 +853,58 @@ class ScenarioOutput(HeatMixin):
                         tags=optim_simulation_tag,
                     )
                     # -- Test tags -- # do not delete - to be used in test case
-                    # prof3 = InfluxDBProfileManager(influxdb_conn_settings)
+
+                    # prof_loaded_from_influxdb = InfluxDBProfileManager(influxdb_conn_settings)
                     # dicts = [{"tag": "output_esdl_id", "value": energy_system.id}]
-                    # prof3.load_influxdb(
+                    # prof_loaded_from_influxdb.load_influxdb(
                     #     # '"' + "ResidualHeatSource_72d7" + '"' ,
                     #     '"' + asset_name + '"' ,
-                    #     ["HeatIn.Q"],
+                    #     variables_one_hydraulic_system,
+                    #     # ["HeatIn.Q"],
                     #     # ["HeatIn.H"],
                     #     # ["Heat_flow"],
                     #     profiles.start_datetime,
                     #     profiles.end_datetime,
                     #     dicts,
                     # )
-                    # test = 0.0
+
+                    # ------------------------------------------------------------------------------
+                    # Do not delete the code below: is used in the development of profile viewer in
+                    # mapeditor
+                    # Write database to excel file and read in to recreate the database
+                    # database name: input esdl id
+                    # tags when saving to database: optim_simulation_tag = {"output_esdl_id":
+                    # output_esdl_id}
+
+                    # print("Save ESDL profile data to excel")
+                    # excel_prof_saved = ExcelProfileManager(
+                    #     source_profile=prof_loaded_from_influxdb
+                    # )
+                    # file_path_setting = (
+                    #     f"C:\\Projects_gitlab\\NWN_dev\\rtc-tools-heat-network\\{asset_name}.xlsx"
+                    # )
+                    # excel_prof_saved.save_excel(
+                    #     file_path=file_path_setting,
+                    #     sheet_name=input_energy_system_id
+                    # )
+                    # print("Read data from Excel")
+                    # excel_prof_read = ExcelProfileManager()
+                    # excel_prof_read.load_excel(file_path_setting)
+                    # print("Create database")
+                    # influxdb_profile_manager_create_new = InfluxDBProfileManager(
+                    #     influxdb_conn_settings, excel_prof_read
+                    # )
+                    # optim_simulation_tag = {"output_esdl_id": energy_system.id}
+                    # _ = influxdb_profile_manager_create_new.save_influxdb(
+                    #     measurement=asset_name,
+                    #     field_names=influxdb_profile_manager_create_new.profile_header[1:],
+                    #     tags=optim_simulation_tag,
+                    # )
+                    # ------------------------------------------------------------------------------
 
                 except Exception:
                     # If the asset has been deleted, thus also not placed
                     pass
-
             # TODO: create test case
             # Code that can be used to remove a specific measurment from the database
             # try:

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -16,6 +16,8 @@ import numpy as np
 
 import pandas as pd
 
+import pytz
+
 from rtctools_heat_network.esdl.edr_pipe_class import EDRPipeClass
 from rtctools_heat_network.heat_mixin import HeatMixin
 from rtctools_heat_network.workflows.utils.helpers import _sort_numbered
@@ -834,6 +836,8 @@ class ScenarioOutput(HeatMixin):
                                     field=profiles.profile_header[-1],
                                     port=self.influxdb_port,
                                     host=self.influxdb_host,
+                                    startDate=pytz.utc.localize(self.io.datetimes[0]),
+                                    endDate=pytz.utc.localize(self.io.datetimes[-1]),
                                 )
                                 asset.port[index_outport].profile.append(profile_attributes)
 
@@ -843,8 +847,8 @@ class ScenarioOutput(HeatMixin):
                         profiles.profile_data_list.append(data_row)
                     # end time steps
                     profiles.num_profile_items = len(profiles.profile_data_list)
-                    profiles.start_datetime = profiles.profile_data_list[0][0]
-                    profiles.end_datetime = profiles.profile_data_list[-1][0]
+                    profiles.start_datetime = pytz.utc.localize(profiles.profile_data_list[0][0])
+                    profiles.end_datetime = pytz.utc.localize(profiles.profile_data_list[-1][0])
 
                     influxdb_profile_manager = InfluxDBProfileManager(
                         influxdb_conn_settings, profiles

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -786,19 +786,20 @@ class ScenarioOutput(HeatMixin):
                         # Get index of outport which will be used to assign the profile data to
                         index_outport = -1
                         for ip in range(len(asset.port)):
-                            if asset.port[ip].name == "Out":
+                            if isinstance(asset.port[ip], esdl.OutPort):
                                 if index_outport == -1:
                                     index_outport = ip
                                 else:
-                                    logger.error(
-                                        f"Asset {asset_name} has more than 1 outport, which is"
-                                        "intended for use to assign result profile data to"
+                                    logger.warning(
+                                        f"Asset {asset_name} has more than 1 OutPort, and the "
+                                        "profile data has been assigned to the 1st OutPort"
                                     )
-                                    sys.exit(1)
+                                    break
+
                         if index_outport == -1:
                             logger.error(
                                 f"Variable {index_outport} has not been assigned to the asset"
-                                "outport"
+                                "OutPort"
                             )
                             sys.exit(1)
 

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -740,11 +740,15 @@ class ScenarioOutput(HeatMixin):
         # Important: This code below must be placed after the "Placement" code. Reason: it relies
         # on unplaced assets being deleted.
         # ------------------------------------------------------------------------------------------
-        # Write asset result profile data to database:
+        # Write asset result profile data to database. The datbase is setup as follows:
+        #   - The each time step is represented by a row of data, with columns datetime, field
+        #     values
+        #   - Database name: input esdl id
+        #   - Measurment: asset name
+        #   - Fields: profile value for the specific variable
         #  - The database contains a measurement (used esdl energy system id as the name for this),
         #    which is a table of the profile results. The each time step is represented by a row of
         #    data, and the columns are: datetime, asset name + "_" variable value
-        #  - At the same time also set the database attributes for each asset with a profile data
         if self.write_result_db_profiles:
             logger.info("Writing asset result profile data to influxDB")
             results = self.extract_results()

--- a/src/rtctools_heat_network/workflows/io/write_output.py
+++ b/src/rtctools_heat_network/workflows/io/write_output.py
@@ -844,7 +844,7 @@ class ScenarioOutput(HeatMixin):
                     # end time steps
                     profiles.num_profile_items = len(profiles.profile_data_list)
                     profiles.start_datetime = profiles.profile_data_list[0][0]
-                    profiles.determine_end_datetime()
+                    profiles.end_datetime = profiles.profile_data_list[-1][0]
 
                     influxdb_profile_manager = InfluxDBProfileManager(
                         influxdb_conn_settings, profiles

--- a/src/rtctools_heat_network/workflows/simulator_workflow.py
+++ b/src/rtctools_heat_network/workflows/simulator_workflow.py
@@ -355,10 +355,23 @@ class NetworkSimulatorHIGHSWeeklyTimeStep(NetworkSimulatorHIGHS):
 @main_decorator
 def main(runinfo_path, log_level):
     logger.info("Run Network Simulator")
+
+    kwargs = {
+        "write_result_db_profiles": False,
+        "influxdb_host": "localhost",
+        "influxdb_port": 8086,
+        "influxdb_username": None,
+        "influxdb_password": None,
+        "influxdb_database": "grow_workflow_test",
+        "influxdb_ssl": False,
+        "influxdb_verify_ssl": False,
+    }
+
     _ = run_optimization_problem(
         NetworkSimulatorHIGHSWeeklyTimeStep,
         esdl_run_info_path=runinfo_path,
         log_level=log_level,
+        **kwargs,
     )
 
 

--- a/src/rtctools_heat_network/workflows/simulator_workflow.py
+++ b/src/rtctools_heat_network/workflows/simulator_workflow.py
@@ -311,7 +311,7 @@ class NetworkSimulator(
 class NetworkSimulatorHIGHS(NetworkSimulator):
     def post(self):
         super().post()
-        self._write_updated_esdl(db_profiles=False, optimizer_sim=False)
+        self._write_updated_esdl(optimizer_sim=False)
 
     def solver_options(self):
         options = super().solver_options()

--- a/src/rtctools_heat_network/workflows/simulator_workflow.py
+++ b/src/rtctools_heat_network/workflows/simulator_workflow.py
@@ -362,7 +362,6 @@ def main(runinfo_path, log_level):
         "influxdb_port": 8086,
         "influxdb_username": None,
         "influxdb_password": None,
-        "influxdb_database": "grow_workflow_test",
         "influxdb_ssl": False,
         "influxdb_verify_ssl": False,
     }


### PR DESCRIPTION
- Update influxDB profile readings based on new functionality in pyESDL v23.10
- Write profile result data to influxDB. For now this has only been implemented
- Upgrade pyESDL to 23.11.1 (includes bug fix)
- Link result profile data influxDB attributes to a port of the asset and write out to esdl. For now the profile data is assigned to the 1st outport of the esdl asset
- Updated the grow_ and simulator_workflow
- Added profile error checks
- Use pyESDL for unit conversions
- Ad versioning of casadi

Still TODO:
- [ ] Create test cases once a server based influxDB can be used, this is aslo needed to test conversion
- [x] Write link result profile data to a port of the asset and write out to esdl 
- [x] change conversion function
- [x] check profile resolution when read -->> error check
- [x] remove hard code fix for <=